### PR TITLE
Create base page object for viewports

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/BasePage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/BasePage.ts
@@ -1,0 +1,10 @@
+export default class BasePage {
+
+    static setDesktopViewport() {
+        cy.viewport('macbook-13')
+    }
+
+    static setLargeDesktopViewport() {
+        cy.viewport(1980, 1080)
+    }
+}

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/bulkCreateProjectPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/bulkCreateProjectPage.ts
@@ -1,4 +1,6 @@
-class BulkCreateProjectPage {
+import BasePage from "./BasePage";
+
+class BulkCreateProjectPage extends BasePage {
     public upload(file: Buffer, filename: string): this {
         cy.getByTestId("upload").selectFile({
             contents: file,

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/confirmTrustPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/confirmTrustPage.ts
@@ -1,4 +1,6 @@
-class ConfirmTrustPage {
+import BasePage from "./BasePage";
+
+class ConfirmTrustPage extends BasePage {
     public verifyConfirmTrustElementsVisible(schoolName: string, validTrustId: string): this {
         cy.getByClass("govuk-back-link").contains("Back");
         cy.getByClass("govuk-heading-xl").getByClass("govuk-caption-l").contains(schoolName);

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/constituencyEditPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/constituencyEditPage.ts
@@ -1,4 +1,6 @@
-class ConstituencyEditPage {
+import BasePage from "./BasePage";
+
+class ConstituencyEditPage extends BasePage {
 
     titleIs(title: string): this {
         cy.getByTestId("title").should("contains.text", title)

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/constituencySearchPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/constituencySearchPage.ts
@@ -1,6 +1,7 @@
+import BasePage from "./BasePage";
 import validationComponent from "./validationComponent";
 
-class ConstituencySearchPage {
+class ConstituencySearchPage extends BasePage {
     public schoolNameIs(school: string): this {
         cy.getByTestId("school-name").should("contains.text", school);
         return this;

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/createProject/createProjectCheckYourAnswersPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/createProject/createProjectCheckYourAnswersPage.ts
@@ -1,4 +1,6 @@
-class CreateProjectCheckYourAnswersPage {
+import BasePage from "../BasePage";
+
+class CreateProjectCheckYourAnswersPage extends BasePage {
     public hasSchoolType(value: string): this {
         cy.getByTestId("school-type").should("contain.text", value);
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/createProject/createProjectPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/createProject/createProjectPage.ts
@@ -1,4 +1,6 @@
-class CreateProjectPage {
+import BasePage from "../BasePage";
+
+class CreateProjectPage extends BasePage {
     public withMethod(method: string): this {
         cy.getByTestId(method).check();
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/datesDetailsPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/datesDetailsPage.ts
@@ -1,9 +1,11 @@
+import BasePage from "./BasePage";
+
 const invalidDateFormatData = "POTATOES";
 const invalidDateDay = "31";
 const dateDay = "28";
 const dateMonth = "2";
 const dateYear = "2025";
-class DatesDetailsPage {
+class DatesDetailsPage extends BasePage{
     
     
     selectSaveAndContinueButton(): this {

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/datesSummaryPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/datesSummaryPage.ts
@@ -1,4 +1,6 @@
-class DatesSummaryPage {
+import BasePage from "./BasePage";
+
+class DatesSummaryPage extends BasePage {
 
     public verifyDatesSummaryElementsVisible(schoolName: string): this {
         cy.getByClass("govuk-heading-xl").getByClass("govuk-caption-l").contains(schoolName);

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/homePage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/homePage.ts
@@ -1,7 +1,7 @@
 import { ProjectRecordCreator } from "cypress/constants/cypressConstants";
 import BasePage from "./BasePage";
 
-class HomePage extends BasePage{
+class HomePage extends BasePage {
 
     public createNewProjects(): this {
         cy.contains("Create new projects").click();

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/homePage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/homePage.ts
@@ -1,6 +1,7 @@
 import { ProjectRecordCreator } from "cypress/constants/cypressConstants";
+import BasePage from "./BasePage";
 
-class HomePage {
+class HomePage extends BasePage{
 
     public createNewProjects(): this {
         cy.contains("Create new projects").click();

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/localAuthorityDetailsPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/localAuthorityDetailsPage.ts
@@ -1,4 +1,6 @@
-class LocalAuthorityDetailsPage {
+import BasePage from "./BasePage";
+
+class LocalAuthorityDetailsPage extends BasePage {
     public checkElementsVisible(schoolName :string): this {
         cy.contains("Back");
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/paginationComponent.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/paginationComponent.ts
@@ -1,6 +1,6 @@
 import BasePage from "./BasePage";
 
-export class PaginationComponent extends BasePage {
+export class PaginationComponent {
     constructor(private prefix: string = "") {}
 
     public next(): this {

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/paginationComponent.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/paginationComponent.ts
@@ -1,4 +1,6 @@
-export class PaginationComponent {
+import BasePage from "./BasePage";
+
+export class PaginationComponent extends BasePage {
     constructor(private prefix: string = "") {}
 
     public next(): this {

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/projectOverviewPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/projectOverviewPage.ts
@@ -1,4 +1,6 @@
-class ProjectOverviewPage {
+import BasePage from "./BasePage";
+
+class ProjectOverviewPage extends BasePage {
 
     public selectTaskListTab(): this {
         cy.contains("Task list").click()

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/regionAndLocalAuthoritySummaryPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/regionAndLocalAuthoritySummaryPage.ts
@@ -1,4 +1,6 @@
-class RegionAndLocalAuthoritySummaryPage {
+import BasePage from "./BasePage";
+
+class RegionAndLocalAuthoritySummaryPage extends BasePage {
 
     public verifyRegionAndLASummaryElementsVisible(schoolName: string): this {
         cy.getByClass("govuk-back-link").contains("Back");

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/regionDetailsPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/regionDetailsPage.ts
@@ -1,4 +1,6 @@
-class RegionDetailsPage {
+import BasePage from "./BasePage";
+
+class RegionDetailsPage extends BasePage {
     public checkElementsVisible(schoolName :string): this {
         cy.contains("Back");
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/risk-appraisal-meeting-page.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/risk-appraisal-meeting-page.ts
@@ -1,4 +1,6 @@
-class RiskAppraisalMeetingEditPage {
+import BasePage from "./BasePage";
+
+class RiskAppraisalMeetingEditPage extends BasePage {
     private errorTracking = "";
     
     titleIs(title: string): this {

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/risk/editProjectRiskPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/risk/editProjectRiskPage.ts
@@ -1,4 +1,6 @@
-class EditProjectRiskPage {
+import BasePage from "../BasePage";
+
+class EditProjectRiskPage extends BasePage{
 
     public hasSchoolName(value: string): this {
         cy.getByTestId(`school-name`).should("contain.text", value);

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/risk/projectRiskSummaryPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/risk/projectRiskSummaryPage.ts
@@ -1,4 +1,6 @@
-class ProjectRiskSummaryPage {
+import BasePage from "../BasePage";
+
+class ProjectRiskSummaryPage extends BasePage {
 
     public hasSchoolName(value: string): this {
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/schoolDetailsPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/schoolDetailsPage.ts
@@ -1,4 +1,6 @@
-class SchoolDetailsPage {
+import BasePage from "./BasePage";
+
+class SchoolDetailsPage extends BasePage {
 
     public verifySchoolDetailsElementsVisible(schoolName: string): this {
         cy.getByClass("govuk-back-link").contains("Back");

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/schoolSummaryPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/schoolSummaryPage.ts
@@ -1,4 +1,6 @@
-class SchoolSummaryPage {
+import BasePage from "./BasePage";
+
+class SchoolSummaryPage extends BasePage {
 
     public verifySchoolSummaryElementsVisible(schoolName: string): this {
         cy.getByClass("govuk-back-link").contains("Back");

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/schoolSummaryPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/schoolSummaryPage.ts
@@ -16,7 +16,7 @@ class SchoolSummaryPage extends BasePage {
         cy.getByClass("govuk-link").eq(3).contains("Change");
 
         cy.getByClass("govuk-summary-list__key").eq(2).contains("School phase");
-        cy.getByClass("govuk-summary-list__value").eq(2).contains("Not set");
+        cy.getByClass("govuk-summary-list__value").eq(2).contains("Empty");
         cy.getByClass("govuk-link").eq(4).contains("Change");
 
         cy.getByClass("govuk-summary-list__key").eq(3).contains("Age range");

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectCheckYourAnswersPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectCheckYourAnswersPage.ts
@@ -1,4 +1,6 @@
-class SingleProjectCheckYourAnswersPage {
+import BasePage from "./BasePage";
+
+class SingleProjectCheckYourAnswersPage extends BasePage {
     public checkElementsVisible(): this {
         cy.contains("Back");
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectConfirmationPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectConfirmationPage.ts
@@ -1,4 +1,6 @@
-class SingleProjectConfirmationPage {
+import BasePage from "./BasePage";
+
+class SingleProjectConfirmationPage extends BasePage {
     public checkElementsVisible(temporaryProjectId): this {
 
         cy.get("h1").contains("Free school project created");

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectCurrentFreeSchoolNamePage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectCurrentFreeSchoolNamePage.ts
@@ -1,6 +1,7 @@
 import { specialCharsTestString } from "cypress/constants/stringTestConstants";
+import BasePage from "./BasePage";
 
-class SingleProjectCurrentFreeSchoolNamePage {
+class SingleProjectCurrentFreeSchoolNamePage extends BasePage {
     public checkElementsVisible(e2eTestSchool): this {
         cy.contains("Back");
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectLocalAuthorityPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectLocalAuthorityPage.ts
@@ -1,4 +1,6 @@
-class SingleProjectLocalAuthorityPage {
+import BasePage from "./BasePage";
+
+class SingleProjectLocalAuthorityPage extends BasePage {
     public checkElementsVisible(): this {
         cy.contains("Back");
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectRegionPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectRegionPage.ts
@@ -1,4 +1,6 @@
-class SingleProjectRegionPage extends BasePage {
+import BasePage from "./BasePage";
+
+class SingleProjectRegionPage extends BasePage{
     public checkElementsVisible(): this {
         cy.contains("Back");
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectRegionPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectRegionPage.ts
@@ -1,4 +1,4 @@
-class SingleProjectRegionPage {
+class SingleProjectRegionPage extends BasePage {
     public checkElementsVisible(): this {
         cy.contains("Back");
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectTemporaryProjectIdPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/singleProjectTemporaryProjectIdPage.ts
@@ -3,8 +3,9 @@
 //let temporaryProjectId = "";
 
 import { specialCharsTestString } from "cypress/constants/stringTestConstants";
+import BasePage from "./BasePage";
 
-class SingleProjectTemporaryProjectIdPage {
+class SingleProjectTemporaryProjectIdPage extends BasePage {
     public checkElementsVisible(): this {
         cy.contains("Back");
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/task-summary-base.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/task-summary-base.ts
@@ -1,4 +1,6 @@
-export class SummaryPage {
+import BasePage from "./BasePage";
+
+export class SummaryPage extends BasePage {
     private summaryCounter = -1;
 
     public inOrder(): this

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/taskListPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/taskListPage.ts
@@ -1,4 +1,6 @@
-class TaskListPage {
+import BasePage from "./BasePage";
+
+class TaskListPage extends BasePage {
 
     public selectDatesFromTaskList(): this {
         cy.getByTestId("dates-task").click()

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/trustDetailsPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/trustDetailsPage.ts
@@ -1,3 +1,5 @@
+import BasePage from "./BasePage";
+
 const invalidTRNString = "POTATO";
 const invalidTRNStringWithSpaces = "P O T A T O";
 const invalidTRNNumbersString = "1234567";
@@ -6,7 +8,7 @@ const nonExistentTrustId = "TR09999";
 const SQLInjectionAttempt = "' OR 1=1";
 const crossSiteScriptingAttempt = "<script>window.alert('Hello World!')</script>";
 
-class TrustDetailsPage {
+class TrustDetailsPage extends BasePage {
     
     
     public selectSaveAndContinue(): this {

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/trustSummaryPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/trustSummaryPage.ts
@@ -1,4 +1,6 @@
-class TrustSummaryPage {
+import BasePage from "./BasePage";
+
+class TrustSummaryPage extends BasePage{
 
     public verifyTrustSummaryElementsVisible(schoolName: string): this {
         cy.getByClass("govuk-back-link").contains("Back");

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/whichProjectMethodPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/whichProjectMethodPage.ts
@@ -1,6 +1,7 @@
+import BasePage from "./BasePage";
 
 
-class WhichProjectMethodPage {
+class WhichProjectMethodPage extends BasePage {
     public checkElementsVisible(): this {
         cy.getByClass("govuk-back-link").contains("Back");
 


### PR DESCRIPTION
Created BasePage class for different Desktop viewports and have used inheritance with all full-page object classes so that we can go through the Cypress tests with different-sized Desktop displays.
Also fixed broken Tasklist-Schools.cy.ts test