### PR TITLE
Add Cypress User-agent to config

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress.config.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     watchForFileChanges: false,
     chromeWebSecurity: false,
     video: false,
+    userAgent: 'ManageFreeSchoolProjects/1.0 Cypress',
     reporter: "cypress-multi-reporters",
     reporterOptions: {
         reporterEnabled: "mochawesome",


### PR DESCRIPTION
Adds a User-Agent header to Cypress' config to mitigate Azure's bot traffic rules