### PR TITLE
Update workflows to use actions on node 20

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -92,7 +92,7 @@ jobs:
           git push origin ${{ needs.set-env.outputs.release }}
 
       - name: Create release
-        uses: "actions/github-script@v6"
+        uses: "actions/github-script@v7"
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
@@ -165,7 +165,7 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload screenshots
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots-${{ needs.set-env.outputs.environment }}
           path: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/screenshots
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: reports-${{ needs.set-env.outputs.environment }}
           path: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/mochareports

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -33,18 +33,18 @@ jobs:
           fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'microsoft'
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar


### PR DESCRIPTION
Updates the github actions versions we use to be ones that support node 20 now that node 16 is being deprecated.

See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/