### PR TITLE
156799: increase the size of link fields to 500

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/pre-opening/draft-governance-plan.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/pre-opening/draft-governance-plan.cy.ts
@@ -92,7 +92,7 @@ describe("Testing draft governance plan task", () => {
             .hasValidationError("Forecast date must include a month and year")
             .hasValidationError("Actual date must include a month and year")
             .hasValidationError("The comments on decision to approve (if applicable) must be 999 characters or less")
-            .hasValidationError("The SharePoint link must be 100 characters or less");
+            .hasValidationError("The SharePoint link must be 500 characters or less");
 
         cy.executeAccessibilityTests();
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/pre-opening/draft-governance-plan.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/pre-opening/draft-governance-plan.cy.ts
@@ -96,6 +96,12 @@ describe("Testing draft governance plan task", () => {
 
         cy.executeAccessibilityTests();
 
+        editDraftGovernancePlanPage
+            .withSharepointLink("aaaa")
+            .clickContinue();
+
+        validationComponent.hasValidationError("The SharePoint link must be a valid url");
+
         Logger.log("Add new values");
         editDraftGovernancePlanPage
             .schoolNameIs(project.schoolName)

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/pre-opening/tasklist-articles-of-association.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/pre-opening/tasklist-articles-of-association.cy.ts
@@ -91,9 +91,9 @@ describe("Testing articles of association Task", () => {
             .withSharepointLink("NotAUrl")
             .clickContinue()
             .errorForSharepointLink().showsError("SharePoint link must be a valid url")
-            .withSharepointLink(`https://www.gov.uk/government/organisations/department-for-education${dataGenerator.generateAlphaNumeric(90)}`)
+            .withSharepointLinkExceedingMaxLength()
             .clickContinue()
-            .errorForSharepointLink().showsError("SharePoint link must be 100 characters or less")
+            .errorForSharepointLink().showsError("SharePoint link must be 500 characters or less")
             .withSharepointLink("https://www.gov.uk/government/organisations/department-for-education")
             .clickContinue();
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/pre-opening/tasklist-kick-off-meeting.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/pre-opening/tasklist-kick-off-meeting.cy.ts
@@ -4,7 +4,6 @@ import { RequestBuilder } from "cypress/api/requestBuilder";
 import dataGenerator from "cypress/fixtures/dataGenerator";
 import summaryPage from "cypress/pages/task-summary-base";
 import taskListPage from "cypress/pages/taskListPage";
-import articlesOfAssociationEditPage from "cypress/pages/tasks/pre-opening/edit-articles-of-association.cy";
 import kickOffMeetingEditPage from "../../../pages/tasks/pre-opening/edit-kick-off-meeting.cy";
 
 describe("Testing kick off meeting Task", () => {
@@ -71,7 +70,7 @@ describe("Testing kick off meeting Task", () => {
             .clickContinue()
 
         cy.executeAccessibilityTests()
-        
+
         summaryPage
             .schoolNameIs(project.schoolName)
             .titleIs("Kick-off meeting")
@@ -93,21 +92,21 @@ describe("Testing kick off meeting Task", () => {
             .withSharepointLink("NotAUrl")
             .clickContinue()
             .errorForSharepointLink().showsError("Sharepoint link must be a valid url")
-            .withSharepointLink(`https://www.gov.uk/government/organisations/department-for-education${dataGenerator.generateAlphaNumeric(90)}`)
+            .withSharepointLinkExceedingMaxLength()
             .clickContinue()
-            .errorForSharepointLink().showsError("Sharepoint link must be 100 characters or less")
+            .errorForSharepointLink().showsError("Sharepoint link must be 500 characters or less")
             .withSharepointLink("https://www.gov.uk/government/organisations/department-for-education")
             .clickContinue();
-        
+
         summaryPage.SummaryHasValue("SharePoint link", "https://www.gov.uk/government/organisations/department-for-education")
             .clickChange();
 
         cy.log("Comment")
-        
+
         kickOffMeetingEditPage
-             .withComments(dataGenerator.generateAlphaNumeric(101))
-             .clickContinue()
-             .errorForComments().showsError("comments must be 100 characters or less")
+            .withComments(dataGenerator.generateAlphaNumeric(101))
+            .clickContinue()
+            .errorForComments().showsError("comments must be 100 characters or less")
 
         kickOffMeetingEditPage
             .withComments("#TaTers")
@@ -115,10 +114,10 @@ describe("Testing kick off meeting Task", () => {
             .errorForComments().showsError("Comments must not include special characters other than , ( ) '")
             .withComments("comment that's ok")
             .clickContinue();
-        
+
         summaryPage.SummaryHasValue("Comments", "comment that's ok")
             .clickChange();
-        
+
         kickOffMeetingEditPage
             .withRealisticYearOfOpeningStartDate("1234")
             .clickContinue()
@@ -148,7 +147,7 @@ describe("Testing kick off meeting Task", () => {
 
         summaryPage.SummaryHasValue("Provisional opening date agreed with trust", "1 March 2050")
             .clickChange();
-        
+
         kickOffMeetingEditPage
             .withFundingArrangementsAgreed("Yes")
             .clickContinue()
@@ -157,11 +156,11 @@ describe("Testing kick off meeting Task", () => {
             .clickChange();
 
         cy.log('Confirm all set')
-        
+
         kickOffMeetingEditPage
             .checkFundingArrangementsAgreed()
             .clickContinue()
-        
+
         summaryPage
             .schoolNameIs(project.schoolName)
             .titleIs("Kick-off meeting")
@@ -174,7 +173,7 @@ describe("Testing kick off meeting Task", () => {
             .isNotMarkedAsComplete()
             .MarkAsComplete()
             .clickConfirmAndContinue();
-        
+
         taskListPage.isTaskStatusIsCompleted("KickOffMeeting");
     })
 })

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/tasks/pre-opening/edit-articles-of-association.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/tasks/pre-opening/edit-articles-of-association.cy.ts
@@ -1,6 +1,6 @@
 class ArticlesOfAssociationEditPage {
     private errorTracking = "";
-    
+
     titleIs(title: string): this {
         cy.getByTestId("title").should("contains.text", title)
         return this;
@@ -11,7 +11,7 @@ class ArticlesOfAssociationEditPage {
         return this;
     }
 
-   
+
     private setDate(key: string, day: string, month: string, year: string) {
         cy.get('#' + `${key}-day`).clear().type(day);
         cy.get('#' + `${key}-month`).clear().type(month);
@@ -32,7 +32,7 @@ class ArticlesOfAssociationEditPage {
         cy.getById("arrangements-match-governance-plans").check()
         return this
     }
-    
+
 
     withForecastDate(day: string, month: string, year: string): this {
         const key = "forecast-date";
@@ -56,47 +56,47 @@ class ArticlesOfAssociationEditPage {
         return this;
     }
 
-    errorForComments(): this
-    {
+    withSharepointLinkExceedingMaxLength(): this {
+        cy.getByTestId("sharepoint-link").clear().invoke("val", `https://${"a".repeat(501)}`);
+        return this;
+    }
+
+    errorForComments(): this {
         this.errorTracking = "comments-on-decision";
-        return this;       
+        return this;
     }
 
-    errorForSharepointLink(): this
-    {
+    errorForSharepointLink(): this {
         this.errorTracking = "sharepoint-link";
-        return this;       
+        return this;
     }
 
-    errorForForecastDate(): this
-    {
+    errorForForecastDate(): this {
         this.errorTracking = "forecast-date";
-        return this;       
+        return this;
     }
 
-    errorForActualDate(): this
-    {
+    errorForActualDate(): this {
         this.errorTracking = "actual-date";
-        return this;       
+        return this;
     }
 
-    showsError(error: string)
-    {
+    showsError(error: string) {
         cy.get(`#${this.errorTracking}-error-link`)
             .should("contain.text", error);
-        
+
         cy.get(`#${this.errorTracking}-error-link`)
-        .invoke('attr', 'href')
-        .then((href) => {
-            cy.get(href as string).should("exist");
-        });
-    
+            .invoke('attr', 'href')
+            .then((href) => {
+                cy.get(href as string).should("exist");
+            });
+
         cy.get(`#${this.errorTracking}-error`)
             .should("contain.text", error);
         return this;
     }
 
-    clickContinue() : this {
+    clickContinue(): this {
         cy.getByTestId("continue").click();
         return this;
     }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/tasks/pre-opening/edit-kick-off-meeting.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/tasks/pre-opening/edit-kick-off-meeting.cy.ts
@@ -1,6 +1,6 @@
 class KickOffMeetingEditPage {
     private errorTracking = "";
-    
+
     titleIs(title: string): this {
         cy.getByTestId("title").should("contains.text", title)
         return this;
@@ -11,7 +11,7 @@ class KickOffMeetingEditPage {
         return this;
     }
 
-   
+
     private setDate(key: string, day: string, month: string, year: string) {
         cy.get('#' + `${key}-day`).clear().type(day);
         cy.get('#' + `${key}-month`).clear().type(month);
@@ -36,7 +36,7 @@ class KickOffMeetingEditPage {
         cy.getById("realistic-year-of-opening-endyear").clear().type(year)
         return this;
     }
-    
+
 
     withProvisionalOpeningDate(day: string, month: string, year: string): this {
         const key = "provisional-opening-date";
@@ -44,17 +44,21 @@ class KickOffMeetingEditPage {
         return this
     }
 
-   
-    
+
+
     withSharepointLink(value: string): this {
         cy.getByTestId("sharepoint-link").clear().type(value)
         return this;
     }
 
-    errorForComments(): this
-    {
+    withSharepointLinkExceedingMaxLength(): this {
+        cy.getByTestId("sharepoint-link").invoke("val", `https://${"a".repeat(501)}`);
+        return this;
+    }
+
+    errorForComments(): this {
         this.errorTracking = "funding-arrangements-details-agreed";
-        return this;       
+        return this;
     }
 
     withFundingArrangementsAgreed(setting: "Yes" | "No"): this {
@@ -68,41 +72,38 @@ class KickOffMeetingEditPage {
             });
         return this;
     }
-    
+
     errorForRealisticStartDate(error: string): this {
         cy.getById('realistic-year-of-opening-error').contains(error)
         return this
     }
 
-    errorForSharepointLink(): this
-    {
+    errorForSharepointLink(): this {
         this.errorTracking = "sharepoint-link";
-        return this;       
+        return this;
     }
 
-    errorForProvisionalOpeningDate(): this
-    {
+    errorForProvisionalOpeningDate(): this {
         this.errorTracking = "provisional-opening-date";
-        return this;       
+        return this;
     }
-    
-    showsError(error: string)
-    {
+
+    showsError(error: string) {
         cy.get(`#${this.errorTracking}-error-link`)
             .should("contain.text", error);
-        
+
         cy.get(`#${this.errorTracking}-error-link`)
-        .invoke('attr', 'href')
-        .then((href) => {
-            cy.get(href as string).should("exist");
-        });
-    
+            .invoke('attr', 'href')
+            .then((href) => {
+                cy.get(href as string).should("exist");
+            });
+
         cy.get(`#${this.errorTracking}-error`)
             .should("contain.text", error);
         return this;
     }
 
-    clickContinue() : this {
+    clickContinue(): this {
         cy.getByTestId("continue").click();
         return this;
     }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/tasks/pre-opening/editDraftGovernancePlanPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/tasks/pre-opening/editDraftGovernancePlanPage.ts
@@ -45,7 +45,7 @@ class EditDraftGovernancePlanPage {
     }
 
     public withSharepointLinkExceedingMaxLength(): this {
-        cy.getById("sharepoint-link").clear().invoke("val", "a".repeat(101));
+        cy.getById("sharepoint-link").clear().invoke("val", "a".repeat(501));
 
         return this;
     }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/tasks/pre-opening/editDraftGovernancePlanPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/tasks/pre-opening/editDraftGovernancePlanPage.ts
@@ -45,7 +45,7 @@ class EditDraftGovernancePlanPage {
     }
 
     public withSharepointLinkExceedingMaxLength(): this {
-        cy.getById("sharepoint-link").clear().invoke("val", "a".repeat(501));
+        cy.getById("sharepoint-link").clear().invoke("val", "https://" + "a".repeat(501));
 
         return this;
     }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Configuration/Existing/MilestonesConfiguration.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Configuration/Existing/MilestonesConfiguration.cs
@@ -237,107 +237,107 @@ namespace Dfe.ManageFreeSchoolProjects.Data.Configuration.Existing
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI103_Comments on decision to approve (if applicable)");
             builder.Property(e => e.FsgPreOpeningMilestonesMi105LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI105_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi107LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI107_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi109LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI109_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi111LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI111_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi113LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI113_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi115LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI115_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi117LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI117_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi119LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI119_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi121LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI121_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi123LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI123_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi125LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI125_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi127LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI127_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi129LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI129_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi131LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI131_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi133LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI133_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi135LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI135_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi137LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI137_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi139LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI139_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi141LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI141_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi143LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI143_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi145LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI145_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi147LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI147_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi149LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI149_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi151LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI151_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi153LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI153_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi155LinkToSavedDocument)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false)
                 .HasColumnName("FSG Pre Opening Milestones.MI155_Link to saved document");
             builder.Property(e => e.FsgPreOpeningMilestonesMi54CommentsOnDecisionToApproveIfApplicable)
@@ -550,7 +550,7 @@ namespace Dfe.ManageFreeSchoolProjects.Data.Configuration.Existing
                 .IsUnicode(false)
                 .HasColumnName("RID");
             builder.Property(e => e.MAASharepointLink)
-                .HasMaxLength(100)
+                .HasMaxLength(500)
                 .IsUnicode(false);
             builder.Property(e => e.MAACommentsOnDecisionToApprove)
                 .HasMaxLength(999)

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Migrations/20240219115756_IncreaseSharePointFieldsTo500.Designer.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Migrations/20240219115756_IncreaseSharePointFieldsTo500.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.ManageFreeSchoolProjects.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.ManageFreeSchoolProjects.Data.Migrations
 {
     [DbContext(typeof(MfspContext))]
-    partial class MfspContextModelSnapshot : ModelSnapshot
+    [Migration("20240219115756_IncreaseSharePointFieldsTo500")]
+    partial class IncreaseSharePointFieldsTo500
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Migrations/20240219115756_IncreaseSharePointFieldsTo500.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Migrations/20240219115756_IncreaseSharePointFieldsTo500.cs
@@ -1,0 +1,720 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.ManageFreeSchoolProjects.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreaseSharePointFieldsTo500 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "MAASharepointLink",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI155_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI153_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI151_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI149_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI147_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI145_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI143_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI141_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI139_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI137_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI135_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI133_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI131_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI129_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI127_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI125_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI123_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI121_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI119_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI117_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI115_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI113_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI111_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI109_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI107_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI105_Link to saved document",
+                table: "Milestones",
+                type: "varchar(500)",
+                unicode: false,
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "MAASharepointLink",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI155_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI153_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI151_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI149_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI147_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI145_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI143_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI141_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI139_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI137_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI135_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI133_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI131_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI129_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI127_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI125_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI123_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI121_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI119_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI117_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI115_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI113_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI111_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI109_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI107_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FSG Pre Opening Milestones.MI105_Link to saved document",
+                table: "Milestones",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(500)",
+                oldUnicode: false,
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+    }
+}

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Constants/ValidationConstants.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Constants/ValidationConstants.cs
@@ -4,5 +4,7 @@
     {
         public const string TextValidationMessage = "The {0} must be {1} characters or less";
         public const string NumberValidationMessage = "{0} must be between {1} and {2}";
+        public const string LinkValidationMessage = "The {0} must be a valid url";
+        public const int LinkMaxLength = 500;
     }
 }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/ArticlesOfAssociation/EditArticlesOfAssociationTask.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/ArticlesOfAssociation/EditArticlesOfAssociationTask.cshtml.cs
@@ -50,6 +50,8 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.ArticlesOfAssociation
 
         [BindProperty(Name = "sharepoint-link")]
         [Display(Name = "SharePoint link")]
+        [StringLength(ValidationConstants.LinkMaxLength, ErrorMessage = ValidationConstants.TextValidationMessage)]
+        [Url(ErrorMessage = ValidationConstants.LinkValidationMessage)]
         public string SharepointLink { get; set; }
 
         public string SchoolName { get; set; }
@@ -77,15 +79,6 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.ArticlesOfAssociation
         {
             var project = await _getProjectService.Execute(ProjectId, TaskName.ArticlesOfAssociation);
             SchoolName = project.SchoolName;
-
-            if (!new UrlAttribute().IsValid(SharepointLink))
-            {
-                ModelState.AddModelError("sharepoint-link", "SharePoint link must be a valid url");
-            }
-            else if (!string.IsNullOrEmpty(SharepointLink) && SharepointLink.Length > 500)
-            {
-                ModelState.AddModelError("sharepoint-link", "SharePoint link must be 500 characters or less");
-            }
 
             if (!ModelState.IsValid)
             {

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/ArticlesOfAssociation/EditArticlesOfAssociationTask.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/ArticlesOfAssociation/EditArticlesOfAssociationTask.cshtml.cs
@@ -82,9 +82,9 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.ArticlesOfAssociation
             {
                 ModelState.AddModelError("sharepoint-link", "SharePoint link must be a valid url");
             }
-            else if (!string.IsNullOrEmpty(SharepointLink) && SharepointLink.Length > 100)
+            else if (!string.IsNullOrEmpty(SharepointLink) && SharepointLink.Length > 500)
             {
-                ModelState.AddModelError("sharepoint-link", "SharePoint link must be 100 characters or less");
+                ModelState.AddModelError("sharepoint-link", "SharePoint link must be 500 characters or less");
             }
 
             if (!ModelState.IsValid)

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/DraftGovernancePlan/EditDraftGovernancePlan.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/DraftGovernancePlan/EditDraftGovernancePlan.cshtml.cs
@@ -40,7 +40,8 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.DraftGovernancePlan
 
         [BindProperty(Name = "sharepoint-link")]
         [DisplayName("SharePoint link")]
-        [StringLength(500, ErrorMessage = ValidationConstants.TextValidationMessage)]
+        [StringLength(ValidationConstants.LinkMaxLength, ErrorMessage = ValidationConstants.TextValidationMessage)]
+        [Url(ErrorMessage = ValidationConstants.LinkValidationMessage)]
         public string SharePointLink { get; set; }
 
         [BindProperty]

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/DraftGovernancePlan/EditDraftGovernancePlan.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/DraftGovernancePlan/EditDraftGovernancePlan.cshtml.cs
@@ -40,7 +40,7 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.DraftGovernancePlan
 
         [BindProperty(Name = "sharepoint-link")]
         [DisplayName("SharePoint link")]
-        [StringLength(100, ErrorMessage = ValidationConstants.TextValidationMessage)]
+        [StringLength(500, ErrorMessage = ValidationConstants.TextValidationMessage)]
         public string SharePointLink { get; set; }
 
         [BindProperty]

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/KickOffMeeting/EditKickOffMeetingTask.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/KickOffMeeting/EditKickOffMeetingTask.cshtml.cs
@@ -1,18 +1,16 @@
 using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks;
+using Dfe.ManageFreeSchoolProjects.Constants;
+using Dfe.ManageFreeSchoolProjects.Logging;
+using Dfe.ManageFreeSchoolProjects.Models;
 using Dfe.ManageFreeSchoolProjects.Services;
 using Dfe.ManageFreeSchoolProjects.Services.Project;
-using Dfe.ManageFreeSchoolProjects.Logging;
+using Dfe.ManageFreeSchoolProjects.Validators;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
-using Dfe.ManageFreeSchoolProjects.Constants;
 using System;
-using Dfe.ManageFreeSchoolProjects.Models;
 using System.ComponentModel.DataAnnotations;
-using System.Runtime.CompilerServices;
-using Dfe.ManageFreeSchoolProjects.Validators;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using System.Threading.Tasks;
 
 
 namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.KickOffMeeting
@@ -76,9 +74,9 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.KickOffMeeting
             {
                 ModelState.AddModelError("sharepoint-link", "Sharepoint link must be a valid url");
             }
-            else if (!string.IsNullOrEmpty(SharepointLink) && SharepointLink.Length > 100)
+            else if (!string.IsNullOrEmpty(SharepointLink) && SharepointLink.Length > 500)
             {
-                ModelState.AddModelError("sharepoint-link", "Sharepoint link must be 100 characters or less");
+                ModelState.AddModelError("sharepoint-link", "Sharepoint link must be 500 characters or less");
             }
 
             if (!ModelState.IsValid)

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/KickOffMeeting/EditKickOffMeetingTask.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/KickOffMeeting/EditKickOffMeetingTask.cshtml.cs
@@ -33,7 +33,7 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.KickOffMeeting
         [ValidText(100)]
         public string FundingArrangementDetailsAgreed { get; set; }
         
-       [BindProperty(Name = "realistic-year-of-opening", BinderType= typeof(StartEndModelBinder))]
+        [BindProperty(Name = "realistic-year-of-opening", BinderType= typeof(StartEndModelBinder))]
         public string RealisticYearOfOpening { get; set; }
         
         [BindProperty(Name = "provisional-opening-date", BinderType = typeof(DateInputModelBinder))]
@@ -42,6 +42,8 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.KickOffMeeting
         
         [BindProperty(Name = "sharepoint-link")]
         [Display(Name = "Sharepoint link")]
+        [StringLength(ValidationConstants.LinkMaxLength, ErrorMessage = ValidationConstants.TextValidationMessage)]
+        [Url(ErrorMessage = ValidationConstants.LinkValidationMessage)]
         public string SharepointLink { get; set; }
 
         public string SchoolName { get; set; }
@@ -69,15 +71,6 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Tasks.KickOffMeeting
         {
             var project = await _getProjectService.Execute(ProjectId, TaskName.KickOffMeeting);
             SchoolName = project.SchoolName;
-
-            if (!new UrlAttribute().IsValid(SharepointLink))
-            {
-                ModelState.AddModelError("sharepoint-link", "Sharepoint link must be a valid url");
-            }
-            else if (!string.IsNullOrEmpty(SharepointLink) && SharepointLink.Length > 500)
-            {
-                ModelState.AddModelError("sharepoint-link", "Sharepoint link must be 500 characters or less");
-            }
 
             if (!ModelState.IsValid)
             {


### PR DESCRIPTION
Link fields are typically bigger than 100 characters, this change increases the limit of all link fields in the database to 500. all fields have been changed so that future tasks don't end up using the 100 limit, which is what the field limit is from the database we imported from KIM originally