### PR TITLE
156809: removed opening academic year from api

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Contracts/Project/Tasks/DatesTask.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Contracts/Project/Tasks/DatesTask.cs
@@ -4,7 +4,6 @@
     public record DatesTask
     {
         public DateTime? DateOfEntryIntoPreopening { get; set; }
-        public string OpeningAcademicYear { get; set; }
         public DateTime? ProvisionalOpeningDateAgreedWithTrust { get; set; }
     }
 }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/ProjectByTaskApiTests.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/ProjectByTaskApiTests.cs
@@ -144,7 +144,6 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
 				{
 					DateOfEntryIntoPreopening = DateTenDaysInFuture,
 					ProvisionalOpeningDateAgreedWithTrust = DateNineDaysInFuture,
-                    OpeningAcademicYear = "2023 2024",
 				}
 			};
 
@@ -152,7 +151,6 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
 
 			projectResponse.Dates.DateOfEntryIntoPreopening.Should().Be(DateTenDaysInFuture);
 			projectResponse.Dates.ProvisionalOpeningDateAgreedWithTrust.Should().Be(DateNineDaysInFuture);
-			projectResponse.Dates.OpeningAcademicYear.Should().Be("2023 2024");
             projectResponse.SchoolName.Should().Be(project.ProjectStatusCurrentFreeSchoolName);
         }
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/Dates/GetDatesTaskService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/Dates/GetDatesTaskService.cs
@@ -1,5 +1,4 @@
 ﻿using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks;
-using Dfe.ManageFreeSchoolProjects.Data.Entities.Existing;
 using Microsoft.EntityFrameworkCore;
 
 namespace Dfe.ManageFreeSchoolProjects.API.UseCases.Project.Tasks.Dates
@@ -16,7 +15,6 @@ namespace Dfe.ManageFreeSchoolProjects.API.UseCases.Project.Tasks.Dates
                 {
                     DateOfEntryIntoPreopening = kpi.ProjectStatusDateOfEntryIntoPreOpening,
                     ProvisionalOpeningDateAgreedWithTrust = kpi.ProjectStatusProvisionalOpeningDateAgreedWithTrust,
-                    OpeningAcademicYear = kpi.ProjectStatusTrustsPreferredYearOfOpening,
                 }
             }).FirstOrDefaultAsync();
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/Dates/UpdateDatesTaskService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/Dates/UpdateDatesTaskService.cs
@@ -13,7 +13,6 @@
             }
 
             dbKpi.ProjectStatusDateOfEntryIntoPreOpening = task.DateOfEntryIntoPreopening;
-            dbKpi.ProjectStatusTrustsPreferredYearOfOpening = task.OpeningAcademicYear;
             dbKpi.ProjectStatusProvisionalOpeningDateAgreedWithTrust = task.ProvisionalOpeningDateAgreedWithTrust;
         }
     }


### PR DESCRIPTION
Since our APIs do not allow partial updating, if we leave the field in, it will get set to null when we update the dates task. Even though the opening academic year field is not visible

Originally it was left in, just in case we changed our minds later, but the impact will change data, which we do not want