### PR TITLE
157217: changed all single or default to first or default

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Controllers/ProjectTaskController.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Controllers/ProjectTaskController.cs
@@ -98,7 +98,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.Controllers
 
         private static TaskSummaryResponse SafeRetrieveTaskSummary(IEnumerable<TaskSummaryResponse> projectTasks, string taskName)
         {
-            return projectTasks.SingleOrDefault(x => x.Name == taskName, new TaskSummaryResponse { Name = taskName, Status = ProjectTaskStatus.NotStarted });
+            return projectTasks.FirstOrDefault(x => x.Name == taskName, new TaskSummaryResponse { Name = taskName, Status = ProjectTaskStatus.NotStarted });
         }
     }
 }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/UpdateProjectByTaskService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/UpdateProjectByTaskService.cs
@@ -54,7 +54,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.UseCases.Project.Tasks
         {
             var taskNameToUpdate = Enum.Parse<TaskName>(updateProjectByTaskRequest.TaskToUpdate);
 
-            var task = await _context.Tasks.SingleOrDefaultAsync(x => x.Rid == taskRid && x.TaskName == taskNameToUpdate);
+            var task = await _context.Tasks.FirstOrDefaultAsync(x => x.Rid == taskRid && x.TaskName == taskNameToUpdate);
             if (task is null)
                 return;
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Tasks/CreateTasksService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Tasks/CreateTasksService.cs
@@ -23,7 +23,7 @@ public class CreateTasksService : ICreateTasksService
 
     public async Task Execute(string projectId)
     {
-        var kpi = await _context.Kpi.SingleOrDefaultAsync(x => x.ProjectStatusProjectId == projectId);
+        var kpi = await _context.Kpi.FirstOrDefaultAsync(x => x.ProjectStatusProjectId == projectId);
         _context.Tasks.AddRange(ProjectTaskBuilder.BuildTasks(kpi.Rid));
         await _context.SaveChangesAsync();
     }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Tasks/GetAllTasksStatusService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Tasks/GetAllTasksStatusService.cs
@@ -27,7 +27,7 @@ public class GetAllTasksStatusService : IGetTasksService
 
     public async Task<GetTasksServiceResult> Execute(string projectId)
     {
-        var dbKpi = await _context.Kpi.SingleOrDefaultAsync(x => x.ProjectStatusProjectId == projectId);
+        var dbKpi = await _context.Kpi.FirstOrDefaultAsync(x => x.ProjectStatusProjectId == projectId);
 
         var dbTasks = await _context.Tasks.Where(x => x.Rid == dbKpi.Rid).ToListAsync();
     

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Tasks/GetTaskStatusService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Tasks/GetTaskStatusService.cs
@@ -21,8 +21,8 @@ public class GetTaskStatusService : IGetTaskStatusService
 
     public async Task<ProjectTaskStatus> Execute(string projectId, string taskName)
     {
-        var dbKpi = await _context.Kpi.SingleOrDefaultAsync(x => x.ProjectStatusProjectId == projectId);
-        var task = await _context.Tasks.SingleOrDefaultAsync(x => x.Rid == dbKpi.Rid && x.TaskName == Enum.Parse<TaskName>(taskName));
+        var dbKpi = await _context.Kpi.FirstOrDefaultAsync(x => x.ProjectStatusProjectId == projectId);
+        var task = await _context.Tasks.FirstOrDefaultAsync(x => x.Rid == dbKpi.Rid && x.TaskName == Enum.Parse<TaskName>(taskName));
         var mappedStatus = (task?.Status ?? Status.InProgress).Map();
         
         return mappedStatus;

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Tasks/UpdateTaskStatusService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Tasks/UpdateTaskStatusService.cs
@@ -21,7 +21,7 @@ public class UpdateTaskStatusService : IUpdateTaskStatusService
 
     public async Task Execute(string projectId, string taskName, ProjectTaskStatus updatedProjectTaskStatus)
     {
-        var dbKpi = await _context.Kpi.SingleOrDefaultAsync(x => x.ProjectStatusProjectId == projectId);
+        var dbKpi = await _context.Kpi.FirstOrDefaultAsync(x => x.ProjectStatusProjectId == projectId);
         
         //taskName might need mapping to TaskName enum if contains multiple words from frontend
         var task = await _context.Tasks.FirstOrDefaultAsync(e => e.Rid == dbKpi.Rid && e.TaskName == Enum.Parse<TaskName>(taskName));

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Create/Individual/LocalAuthority.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Create/Individual/LocalAuthority.cshtml.cs
@@ -68,7 +68,7 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.Create
             }
             
             project.LocalAuthority = LocalAuthority;
-            project.LocalAuthorityCode = project.LocalAuthorities.SingleOrDefault(x => x.Value == LocalAuthority).Key;
+            project.LocalAuthorityCode = project.LocalAuthorities.FirstOrDefault(x => x.Value == LocalAuthority).Key;
 
             if (project.ReachedCheckYourAnswers)
             {

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/RegionAndLA/EditLocalAuthority.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/RegionAndLA/EditLocalAuthority.cshtml.cs
@@ -82,7 +82,7 @@ public class EditLocalAuthority : PageModel
 
         localAuthorities = await GetLocalAuthoritiesByRegion();
 
-        var localAuthorityCode = localAuthorities.SingleOrDefault(x => x.Value == LocalAuthority).Key;
+        var localAuthorityCode = localAuthorities.FirstOrDefault(x => x.Value == LocalAuthority).Key;
         
         await _updateProjectByTaskService.Execute(ProjectId, new UpdateProjectByTaskRequest
         {

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Services/ErrorService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Services/ErrorService.cs
@@ -35,7 +35,7 @@ namespace Dfe.ManageFreeSchoolProjects.Services
 		
 		public Error GetError(string key)
 		{
-			return _errors.SingleOrDefault(e => e.Key == key);
+			return _errors.FirstOrDefault(e => e.Key == key);
 		}
 
 		public IEnumerable<Error> GetErrors()


### PR DESCRIPTION
single or default will throw an error if more than one record is found, we should use our gateways to make sure the data is correct, rather than throwing errors in a random part of the code

the bug that has been fixed was duplicated project ids, which are validated by the client journey