### PR TITLE
fix cypress tests that failed on 08-04-24

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Helpers/DatabaseModelBuilder.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Helpers/DatabaseModelBuilder.cs
@@ -76,7 +76,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Helpers
             {
                 Rid = _fixture.Create<string>().Substring(0, 10),
                 AprilIndicator = _fixture.Create<string>().Substring(0, 9),
-                Wave = _fixture.Create<string>().Substring(0, 15),
+                Wave = CreateProjectWave(),
                 UpperStatus = _fixture.Create<string>().Substring(0, 10),
                 FsType = _fixture.Create<string>().Substring(0, 13),
                 FsType1 = _fixture.Create<string>().Substring(0, 15),
@@ -117,6 +117,11 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Helpers
         public static string CreateProjectId()
         {
             return _fixture.Create<string>().Substring(0, 24);
+        }
+
+        public static string CreateProjectWave()
+        {
+            return _fixture.Create<string>().Substring(0, 15);
         }
 
         public static RiskAppraisalMeetingTask BuildRiskAppraisalMeetingTask(string rid)

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/AuditTests.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/AuditTests.cs
@@ -120,8 +120,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
             var request = new CreateProjectRequest();
             projectDetails.TRN = trust.TrustRef;
 
-            var truncatedWave = projectDetails.ApplicationWave.Substring(0, 15);
-            projectDetails.ApplicationWave = truncatedWave;
+            projectDetails.ApplicationWave = DatabaseModelBuilder.CreateProjectWave();
 
             request.Projects.Add(projectDetails);
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/ProjectApiTests.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/ProjectApiTests.cs
@@ -34,8 +34,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
             projectDetails.SchoolPhase = SchoolPhase.Primary;
             projectDetails.Nursery = ClassType.Nursery.Yes;
 
-            var truncatedWave = projectDetails.ApplicationWave.Substring(0, 15);
-            projectDetails.ApplicationWave = truncatedWave;
+            projectDetails.ApplicationWave = DatabaseModelBuilder.CreateProjectWave();
 
             var request = new CreateProjectRequest();
             projectDetails.TRN = trust.TrustRef;
@@ -115,8 +114,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
             var request = new CreateProjectRequest();
             projectDetails.TRN = trust.TrustRef;
 
-            var truncatedWave = projectDetails.ApplicationWave.Substring(0, 15);
-            projectDetails.ApplicationWave = truncatedWave;
+            projectDetails.ApplicationWave = DatabaseModelBuilder.CreateProjectWave();
 
             request.Projects.Add(projectDetails);
 
@@ -161,12 +159,9 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
             proj2.TRN = trust2.TrustRef;
             proj3.TRN = trust3.TrustRef;
 
-            var truncatedWave1 = proj1.ApplicationWave.Substring(0, 15);
-            var truncatedWave2 = proj2.ApplicationWave.Substring(0, 15);
-            var truncatedWave3 = proj3.ApplicationWave.Substring(0, 15);
-            proj1.ApplicationWave = truncatedWave1;
-            proj2.ApplicationWave = truncatedWave2;
-            proj3.ApplicationWave = truncatedWave3;
+            proj1.ApplicationWave = DatabaseModelBuilder.CreateProjectWave();
+            proj2.ApplicationWave = DatabaseModelBuilder.CreateProjectWave();
+            proj3.ApplicationWave = DatabaseModelBuilder.CreateProjectWave();
 
 
             request.Projects.AddRange(new List<ProjectDetails>
@@ -210,8 +205,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
 
             CreateProjectRequest request = new CreateProjectRequest();
             proj1.TRN = trust.TrustRef;
-            var truncatedWave = proj1.ApplicationWave.Substring(0, 15);
-            proj1.ApplicationWave = truncatedWave;
+            proj1.ApplicationWave = DatabaseModelBuilder.CreateProjectWave();
             request.Projects.Add(proj1);
 
             var projectId = DatabaseModelBuilder.CreateProjectId();

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/ProjectRiskApiTests.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/ProjectRiskApiTests.cs
@@ -326,12 +326,10 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
             var trust = DatabaseModelBuilder.BuildTrust();
             
             var truncatedTRN = project.TRN.Substring(0, 5);
-
-            var truncatedWave = project.ApplicationWave.Substring(0, 15);
             
             project.TRN = truncatedTRN;
             trust.TrustRef = truncatedTRN;
-            project.ApplicationWave = truncatedWave;
+            project.ApplicationWave = DatabaseModelBuilder.CreateProjectWave();
 
             context.Trust.Add(trust);
             await context.SaveChangesAsync();

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/CreateProjectService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/CreateProjectService.cs
@@ -119,7 +119,6 @@ namespace Dfe.ManageFreeSchoolProjects.API.UseCases.Project
                 SchoolDetailsPleaseSpecifyOtherFaithType = proj.OtherFaithType,
                 ProjectStatusProvisionalOpeningDateAgreedWithTrust = proj.ProvisionalOpeningDate,
                 KeyContactsFsgLeadContact = proj.ProjectLead,
-                
             };
         }
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/api/requestBuilder.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/api/requestBuilder.ts
@@ -8,7 +8,7 @@ export class RequestBuilder {
         const result: ProjectDetailsRequest = {
             projectId: dataGenerator.generateTemporaryId(),
             applicationNumber: v4().substring(0, 9),
-            applicationWave: v4(),
+            applicationWave: "FS - Presumption",
             createdBy: Cypress.env(EnvUsername),
             schoolName: dataGenerator.generateSchoolName(),
             TRN: 'TR00111'

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/Getting-ready-to-open/applications-evidence.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/Getting-ready-to-open/applications-evidence.cy.ts
@@ -49,7 +49,7 @@ describe("Testing the applications evidence task", () => {
         Logger.log("Applications evidence can save null values");
 
         applicationsEvidenceEditPage
-        .clickContinue()
+            .clickContinue()
 
         summaryPage
             .schoolNameIs(project.schoolName)
@@ -65,8 +65,8 @@ describe("Testing the applications evidence task", () => {
         cy.executeAccessibilityTests();
 
         Logger.log("Applications evidence can be edited");
-        
-        
+
+
 
         applicationsEvidenceEditPage
             .withComments("!")
@@ -77,7 +77,7 @@ describe("Testing the applications evidence task", () => {
             .checkBuildUpFormSavedToWorkplaces()
             .checkUnderWritingAgreementSavedToWorkplaces()
             .clickContinue()
-        
+
 
         Logger.log("Should update the task status");
 
@@ -119,12 +119,12 @@ describe("Testing the applications evidence task", () => {
             .clickConfirmAndContinue()
 
         Logger.log("Should not be able to see task if school type special");
-        
+
         taskListPage.isTaskStatusIsCompleted("ApplicationsEvidence")
             .selectSchoolFromTaskList()
-        
+
         summaryPage.clickChange()
-        
+
         schoolDetailsPage
             .withSchoolName("Test School")
             .withSchoolType("Special")
@@ -139,14 +139,14 @@ describe("Testing the applications evidence task", () => {
             .withFaithStatus("Designation")
             .withFaithType("Jewish")
             .clickContinue();
-        
+
         summaryPage.clickConfirmAndContinue()
-        
+
         taskListPage.assertApplicationsEvidenceIsNotVisibleTaskList()
             .selectSchoolFromTaskList()
 
         Logger.log("Should not be able to see task if school type AP");
-        
+
         summaryPage.clickChange()
 
         schoolDetailsPage

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/setting-up/Tasklist-School.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/setting-up/Tasklist-School.cy.ts
@@ -118,6 +118,7 @@ describe("Testing project overview", () => {
             .clickChange();
 
         Logger.log("Update the existing values");
+        Logger.log("When special is selected alternative provision and special educational needs are not displayed");
         schoolDetailsPage
             .withSchoolType("Special")
             .withSchoolPhase("Primary")
@@ -128,6 +129,8 @@ describe("Testing project overview", () => {
             .withSixthForm("Yes")
             .withFaithStatus("Ethos")
             .withFaithType("Christian")
+            .hasNoAlternativeProvision()
+            .hasNoSpecialEducationNeeds()
             .clickContinue();
 
         summaryPage
@@ -143,6 +146,8 @@ describe("Testing project overview", () => {
             .summaryShows("Sixth form").HasValue("Yes")
             .summaryShows("Faith status").HasValue("Ethos")
             .summaryShows("Faith type").HasValue("Christian")
+            .summaryDoesNotShow("Alternative provision")
+            .summaryDoesNotShow("Special educational needs")
             .clickChange();
 
         Logger.log("Checking faith type 'Other'");

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/schoolDetailsPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/schoolDetailsPage.ts
@@ -66,8 +66,19 @@ class SchoolDetailsPage {
         return this;
     }
 
+    public hasNoAlternativeProvision(): this {
+        cy.containsByTestId(`alternative-provision`).should("not.be.visible");
+        return this;
+    }
+
     public withSpecialEducationNeeds(value: string): this {
         cy.getByTestId(`special-education-needs-${value}`).check();
+        return this;
+    }
+
+    public hasNoSpecialEducationNeeds(): this {
+        cy.containsByTestId(`special-education-needs`).should("not.be.visible");
+
         return this;
     }
 


### PR DESCRIPTION
set the wave when creating projects in cypress
check that alternative provision and special needs are not shown if school is special