### PR TITLE
162612: Related links on pupil numbers

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Contracts/Project/Tasks/ProjectByTaskSummaryResponse.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Contracts/Project/Tasks/ProjectByTaskSummaryResponse.cs
@@ -53,5 +53,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks
     {
         public string Name { get; set; }
         public ProjectTaskStatus Status { get; set; }
+
+        public bool IsHidden { get; set; }
     }
 }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/GetProjectByTaskSummaryApiTests.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Integration/GetProjectByTaskSummaryApiTests.cs
@@ -2,10 +2,10 @@
 using Dfe.ManageFreeSchoolProjects.API.Contracts.ResponseModels;
 using Dfe.ManageFreeSchoolProjects.API.Tests.Fixtures;
 using Dfe.ManageFreeSchoolProjects.API.Tests.Helpers;
+using Dfe.ManageFreeSchoolProjects.API.Tests.Utils;
 using System.Net;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
-using Dfe.ManageFreeSchoolProjects.API.Tests.Utils;
 
 namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
 {
@@ -66,6 +66,40 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Integration
 
             result.PDG.Name.Should().Be(TaskName.PDG.ToString());
             result.PDG.Status.Should().Be(ProjectTaskStatus.NotStarted);
+
+            result.ApplicationsEvidence.Name.Should().Be(TaskName.ApplicationsEvidence.ToString());
+            result.ApplicationsEvidence.Status.Should().Be(ProjectTaskStatus.NotStarted);
+        }
+
+        [Fact]
+        public async Task GetProjectTaskList_ApplicationsEvidence_HiddenWithSchoolType_Returns_200()
+        {
+            using var context = _testFixture.GetContext();
+            
+            var project = DatabaseModelBuilder.BuildProject();
+            project.SchoolDetailsSchoolTypeMainstreamApEtc = "FS - AP";
+
+            context.Kpi.Add(project);
+
+            await context.SaveChangesAsync();
+
+            var taskListResponse = await _client.GetAsync($"/api/v1/client/projects/{project.ProjectStatusProjectId}/tasks/summary");
+            taskListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var content = await taskListResponse.Content.ReadFromJsonAsync<ApiSingleResponseV2<ProjectByTaskSummaryResponse>>();
+
+            var result = content.Data;
+
+            result.ApplicationsEvidence.Name.Should().Be(TaskName.ApplicationsEvidence.ToString());
+            result.ApplicationsEvidence.Status.Should().Be(ProjectTaskStatus.NotStarted);
+            result.ApplicationsEvidence.IsHidden.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Get_ProjectTaskList_ProjectDoesNotExist_Returns_404()
+        {
+            var taskListResponse = await _client.GetAsync($"/api/v1/client/projects/NotExist/tasks/summary");
+            taskListResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
     }
 }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Project/Tasks/ApplicationsEvidenceTaskSummaryBuilderTests.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Project/Tasks/ApplicationsEvidenceTaskSummaryBuilderTests.cs
@@ -1,0 +1,35 @@
+﻿using Dfe.ManageFreeSchoolProjects.API.Contracts.Project;
+using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks;
+using Dfe.ManageFreeSchoolProjects.API.UseCases.Project.Tasks.ApplicationsEvidence;
+
+namespace Dfe.ManageFreeSchoolProjects.API.Tests.Project.Tasks
+{
+    public class ApplicationsEvidenceTaskSummaryBuilderTests
+    {
+        [Theory]
+        [InlineData(SchoolType.FurtherEducation, false)]
+        [InlineData(SchoolType.Mainstream, false)]
+        [InlineData(SchoolType.AlternativeProvision, true)]
+        [InlineData(SchoolType.Special, true)]
+        public void Build(SchoolType schoolType, bool isHidden)
+        {
+            // Arrange
+            var builder = new ApplicationsEvidenceTaskSummaryBuilder();
+            var parameters = new ApplicationsEvidenceTaskSummaryBuilderParameters
+            {
+                SchoolType = schoolType,
+                TaskSummary = new TaskSummaryResponse
+                {
+                    Name = TaskName.ApplicationsEvidence.ToString(),
+                    Status = ProjectTaskStatus.NotStarted,
+                }
+            };
+
+            // Act
+            var actual = builder.Build(parameters);
+
+            // Assert
+            actual.IsHidden.Should().Be(isHidden);
+        }
+    }
+}

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Controllers/ProjectTaskController.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Controllers/ProjectTaskController.cs
@@ -1,7 +1,6 @@
 ﻿using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks;
 using Dfe.ManageFreeSchoolProjects.API.Contracts.ResponseModels;
 using Dfe.ManageFreeSchoolProjects.API.UseCases.Project.Tasks;
-using Dfe.ManageFreeSchoolProjects.API.UseCases.Project.Tasks.DraftGovernancePlan;
 using Dfe.ManageFreeSchoolProjects.API.UseCases.Tasks;
 using Dfe.ManageFreeSchoolProjects.Logging;
 using Microsoft.AspNetCore.Mvc;
@@ -65,45 +64,11 @@ namespace Dfe.ManageFreeSchoolProjects.API.Controllers
         {
             _logger.LogMethodEntered();
             
-            var result = await _getTasksService.Execute(projectId);
-            
-            var projectTasks = result.taskSummaryResponses;
-
-            var summary = new ProjectByTaskSummaryResponse
-            {
-                SchoolName = result.CurrentFreeSchoolName,
-                School = SafeRetrieveTaskSummary(projectTasks, "School"),
-                Dates = SafeRetrieveTaskSummary(projectTasks,"Dates"),
-                Trust = SafeRetrieveTaskSummary(projectTasks, "Trust"), 
-                RegionAndLocalAuthority = SafeRetrieveTaskSummary(projectTasks, "RegionAndLocalAuthority"),
-                RiskAppraisalMeeting = SafeRetrieveTaskSummary(projectTasks, "RiskAppraisalMeeting"),
-                Constituency = SafeRetrieveTaskSummary(projectTasks, "Constituency"),
-                ModelFundingAgreement = SafeRetrieveTaskSummary(projectTasks,"ModelFundingAgreement"),
-                StatutoryConsultation = SafeRetrieveTaskSummary(projectTasks, "StatutoryConsultation"),
-                ArticlesOfAssociation = SafeRetrieveTaskSummary(projectTasks, "ArticlesOfAssociation"),
-                FinancePlan = SafeRetrieveTaskSummary(projectTasks, "FinancePlan"),
-                KickOffMeeting = SafeRetrieveTaskSummary(projectTasks,"KickOffMeeting"),
-                Gias = SafeRetrieveTaskSummary(projectTasks,"Gias"),
-                DraftGovernancePlan = SafeRetrieveTaskSummary(projectTasks, TaskName.DraftGovernancePlan.ToString()),
-                EducationBrief = SafeRetrieveTaskSummary(projectTasks,"EducationBrief"),
-                EqualitiesAssessment = SafeRetrieveTaskSummary(projectTasks, "EqualitiesAssessment"),
-                AdmissionsArrangements = SafeRetrieveTaskSummary(projectTasks, "AdmissionsArrangements"),  
-                ImpactAssessment = SafeRetrieveTaskSummary(projectTasks, "ImpactAssessment"), 
-                EvidenceOfAcceptedOffers = SafeRetrieveTaskSummary(projectTasks, "EvidenceOfAcceptedOffers"),
-                OfstedInspection = SafeRetrieveTaskSummary(projectTasks, "OfstedInspection"),
-                ApplicationsEvidence = SafeRetrieveTaskSummary(projectTasks, "ApplicationsEvidence"),
-                FundingAgreementHealthCheck = SafeRetrieveTaskSummary(projectTasks, "FundingAgreementHealthCheck"),
-                PDG = SafeRetrieveTaskSummary(projectTasks, "PDG"),
-            };
+            var summary = await _getTasksService.Execute(projectId);
            
             var response = new ApiSingleResponseV2<ProjectByTaskSummaryResponse>(summary);
 
             return new ObjectResult(response) { StatusCode = StatusCodes.Status200OK };
-        }
-
-        private static TaskSummaryResponse SafeRetrieveTaskSummary(IEnumerable<TaskSummaryResponse> projectTasks, string taskName)
-        {
-            return projectTasks.FirstOrDefault(x => x.Name == taskName, new TaskSummaryResponse { Name = taskName, Status = ProjectTaskStatus.NotStarted });
         }
     }
 }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/ApplicationsEvidence/ApplicationsEvidenceTaskSummaryBuilder.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/ApplicationsEvidence/ApplicationsEvidenceTaskSummaryBuilder.cs
@@ -1,0 +1,27 @@
+﻿using Dfe.ManageFreeSchoolProjects.API.Contracts.Project;
+using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks;
+
+namespace Dfe.ManageFreeSchoolProjects.API.UseCases.Project.Tasks.ApplicationsEvidence
+{
+    public record ApplicationsEvidenceTaskSummaryBuilderParameters
+    {
+        public SchoolType SchoolType { get; set; }
+        public TaskSummaryResponse TaskSummary { get; set; }
+    }
+
+    public class ApplicationsEvidenceTaskSummaryBuilder
+    {
+        public TaskSummaryResponse Build(ApplicationsEvidenceTaskSummaryBuilderParameters parameters)
+        {
+            var taskSummary = parameters.TaskSummary;
+            var schoolType = parameters.SchoolType;
+
+            if (schoolType is SchoolType.AlternativeProvision or SchoolType.Special)
+            {
+                taskSummary.IsHidden = true;
+            }
+
+            return taskSummary;
+        }
+    }
+}

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/Getting-ready-to-open/applications-evidence.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/Getting-ready-to-open/applications-evidence.cy.ts
@@ -140,19 +140,8 @@ describe("Testing the applications evidence task", () => {
 
         summaryPage.clickConfirmAndContinue()
 
+        Logger.log("Should not be able to see applications evidence task if school type is not special")
         taskListPage.assertApplicationsEvidenceIsNotVisibleTaskList()
-            .selectSchoolFromTaskList()
-
-        Logger.log("Should not be able to see task if school type AP");
-
-        summaryPage.clickChange()
-
-        schoolDetailsPage
-            .withSchoolType("AlternativeProvision")
-            .clickContinue();
-
-        summaryPage.clickConfirmAndContinue()
-
-        Logger.log("Should not be able to see task if school type AP");
+            .selectSchoolFromTaskList();
     });
 });

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/Getting-ready-to-open/applications-evidence.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/tasks/Getting-ready-to-open/applications-evidence.cy.ts
@@ -141,7 +141,6 @@ describe("Testing the applications evidence task", () => {
         summaryPage.clickConfirmAndContinue()
 
         Logger.log("Should not be able to see applications evidence task if school type is not special")
-        taskListPage.assertApplicationsEvidenceIsNotVisibleTaskList()
-            .selectSchoolFromTaskList();
+        taskListPage.assertApplicationsEvidenceIsNotVisibleTaskList();
     });
 });

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/taskListPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/taskListPage.ts
@@ -112,7 +112,7 @@ class TaskListPage {
     }
 
     public selectApplicationsEvidenceFromTaskList(): this {
-        cy.getByTestId("applicationsevidence-task").click()
+        this.getApplicationsEvidenceTask().click()
         return this;
     }
 
@@ -122,7 +122,7 @@ class TaskListPage {
     }
 
     public assertApplicationsEvidenceIsNotVisibleTaskList(): this {
-        cy.getByTestId("applicationsevidence-task").should("not.exist")
+        this.getApplicationsEvidenceTask().should("not.exist")
         return this;
     }
 
@@ -143,6 +143,11 @@ class TaskListPage {
 
     private getDraftGovernancePlanTask() {
         return cy.getByTestId("draft-governance-plan-task");
+    }
+
+    private getApplicationsEvidenceTask() {
+        return cy.getByTestId("ApplicationsEvidence-task");
+
     }
 }
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/PupilNumbers/ViewPupilNumbers.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/PupilNumbers/ViewPupilNumbers.cshtml
@@ -16,6 +16,7 @@
     var editRecruitmentAndViabilityLink = string.Format(RouteConstants.EditRecruitmentAndViability, Model.ProjectId);
     var editPre16CapacityBuildupLink = string.Format(RouteConstants.EditPre16CapacityBuildup, Model.ProjectId);
     var editPost16CapacityBuildupLink = string.Format(RouteConstants.EditPost16CapacityBuildup, Model.ProjectId);
+    var applicationsEvidenceLink = string.Format(RouteConstants.ViewApplicationsEvidenceTask, Model.ProjectId);
 }
 
 @section BeforeMain {
@@ -273,7 +274,7 @@
 
         <a class="govuk-button govuk-!-margin-bottom-9" href="@editPost16CapacityBuildupLink" data-testid="edit-post16-capacity-buildup">Edit Post-16 capacity buildup</a>
 
-
+        @*
         <div class="govuk-grid-row govuk-!-margin-top-6">
             <div class="govuk-grid-column-two-thirds">
 
@@ -284,32 +285,10 @@
                 <p class="govuk-body">You may want to complete the following related tasks.</p>
 
                 <ol class="app-task-list">
-                    <li class="app-task-list__item">
-                        <span class="app-task-list__task-name">
-                            <a href="task-applications-evidence-landing-page" aria-describedby="contact-details-status">
-                                Applications evidence
-                            </a>
-                        </span>
-                        <strong class='govuk-tag govuk-tag--grey app-task-list__tag'>Not started</strong>
-                    </li>
-                    <li class="app-task-list__item">
-                        <span class="app-task-list__task-name">
-                            <a href="task-accepted-place-offers-evidence-landing-page" aria-describedby="contact-details-status">
-                                Accepted place offers evidence
-                            </a>
-                        </span>
-                        <strong class='govuk-tag govuk-tag--grey app-task-list__tag'>Not started</strong>
-                    </li>
-                    <li class="app-task-list__item">
-                        <span class="app-task-list__task-name">
-                            <a href="task-pupil-numbers-checks-landing-page" aria-describedby="contact-details-status">
-                                Pupil numbers checks
-                            </a>
-                        </span>
-                        <strong class='govuk-tag govuk-tag--grey app-task-list__tag'>Not started</strong>
-                    </li>
+                    <govuk-task-summary-item asp-for="@Model.ProjectTaskListSummary.ApplicationsEvidence" href="@applicationsEvidenceLink" label="Applications evidence" />
                 </ol>
             </div>
         </div>
+        *@
     </div>
 </div>

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/PupilNumbers/ViewPupilNumbers.cshtml.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/PupilNumbers/ViewPupilNumbers.cshtml.cs
@@ -1,4 +1,5 @@
 using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.PupilNumbers;
+using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks;
 using Dfe.ManageFreeSchoolProjects.Services.Project;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -13,19 +14,26 @@ namespace Dfe.ManageFreeSchoolProjects.Pages.Project.PupilNumbers
 
         public GetPupilNumbersResponse PupilNumbers { get; set; }
 
+        public ProjectByTaskSummaryResponse ProjectTaskListSummary { get; set; }
+
         [BindProperty(SupportsGet = true, Name = "fromSaveForm")]
         public bool ShowBanner { get; set; }
 
         private readonly IGetPupilNumbersService _getPupilNumbersService;
+        private readonly IGetProjectByTaskSummaryService _getProjectByTaskSummaryService;
 
-        public ViewPupilNumbersModel(IGetPupilNumbersService getPupilNumbersService)
+        public ViewPupilNumbersModel(
+            IGetPupilNumbersService getPupilNumbersService, 
+            IGetProjectByTaskSummaryService getProjectByTaskSummaryService)
         {
             _getPupilNumbersService = getPupilNumbersService;
+            _getProjectByTaskSummaryService = getProjectByTaskSummaryService;
         }
 
         public async Task<IActionResult> OnGet()
         {
             PupilNumbers = await _getPupilNumbersService.Execute(ProjectId);
+            ProjectTaskListSummary = await _getProjectByTaskSummaryService.Execute(ProjectId);
 
             return Page();
         }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/TaskList.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/TaskList.cshtml
@@ -299,19 +299,7 @@
                     Getting ready to open
                 </h2>
                 <ul class="app-task-list__items">
-                    @if (!Model.ProjectTaskListSummary.ApplicationsEvidence.IsHidden)
-                    {
-                        <li class="app-task-list__item">
-                            <span class="app-task-list__task-name">
-                                <a href="@applicationsEvidenceLink" class="govuk-link" data-testid="applicationsevidence-task">
-                                    Applications evidence
-                                </a>
-                            </span>
-                            @{
-                                RenderStatus(Model.ProjectTaskListSummary.ApplicationsEvidence);
-                            }
-                        </li>
-                    }
+                    <govuk-task-summary-item asp-for="@Model.ProjectTaskListSummary.ApplicationsEvidence" href="@applicationsEvidenceLink" label="Applications evidence" />
                     <li class="app-task-list__item">
                         <span class="app-task-list__task-name">
                             <a href="@acceptedOffersEvidenceLink" class="govuk-link" data-testid="acceptedoffersevidence-task">

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/TaskList.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Tasks/TaskList.cshtml
@@ -299,7 +299,7 @@
                     Getting ready to open
                 </h2>
                 <ul class="app-task-list__items">
-                    @if(Model.SchoolType is not (SchoolType.AlternativeProvision or SchoolType.Special))
+                    @if (!Model.ProjectTaskListSummary.ApplicationsEvidence.IsHidden)
                     {
                         <li class="app-task-list__item">
                             <span class="app-task-list__task-name">

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Shared/_TaskSummaryItem.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Shared/_TaskSummaryItem.cshtml
@@ -1,0 +1,35 @@
+﻿@using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks
+@using Dfe.ManageFreeSchoolProjects.TagHelpers
+@model TaskSummaryItemViewModel
+
+<li class="app-task-list__item">
+    <span class="app-task-list__task-name">
+        <a href="@Model.Href" class="govuk-link" data-testid="@Model.TaskSummary.Name-task">
+            @Model.Label
+        </a>
+    </span>
+    @{
+        RenderStatus(Model.TaskSummary);
+    }
+</li>
+
+@functions {
+
+    public void RenderStatus(TaskSummaryResponse task)
+    {
+        var testId = $"task-{task.Name}-status";
+
+        if (task.Status == ProjectTaskStatus.Completed)
+        {
+            <strong class="govuk-tag app-task-list__tag" data-testid="@testId">Completed</strong>
+        }
+        else if (task.Status == ProjectTaskStatus.InProgress)
+        {
+            <strong class="govuk-tag govuk-tag--blue app-task-list__tag" data-testid="@testId">In progress</strong>
+        }
+        else
+        {
+            <strong class="govuk-tag govuk-tag--grey app-task-list__tag" data-testid="@testId">Not started</strong>
+        }
+    }
+}

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/TagHelpers/TaskSummaryItemTagHelper.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/TagHelpers/TaskSummaryItemTagHelper.cs
@@ -1,0 +1,66 @@
+﻿using Dfe.ManageFreeSchoolProjects.API.Contracts.Project.Tasks;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Dfe.ManageFreeSchoolProjects.TagHelpers
+{
+    [HtmlTargetElement("govuk-task-summary-item", TagStructure = TagStructure.WithoutEndTag)]
+    public class TaskSummaryItemTagHelper : TagHelper
+    {
+        private readonly IHtmlHelper _htmlHelper;
+
+        [HtmlAttributeName("asp-for")]
+        public ModelExpression For { get; set; }
+
+        [HtmlAttributeName("href")]
+        public string Href { get; set; }
+
+        [HtmlAttributeName("label")]
+        public string Label { get; set; }
+
+        [ViewContext]
+        public ViewContext ViewContext { get; set; }
+
+        public TaskSummaryItemTagHelper(IHtmlHelper htmlHelper)
+        {
+            _htmlHelper = htmlHelper;
+        }
+
+        public async override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (_htmlHelper is IViewContextAware viewContextAware)
+            {
+                viewContextAware.Contextualize(ViewContext);
+            }
+
+            var model = new TaskSummaryItemViewModel()
+            {
+                TaskSummary = For.Model as TaskSummaryResponse,
+                Href = Href,
+                Label = Label
+            };
+
+            if (model.TaskSummary.IsHidden)
+            {
+                output.SuppressOutput();
+
+                return;
+            }
+
+            var content = await _htmlHelper.PartialAsync("_TaskSummaryItem", model);
+
+            output.TagName = null;
+            output.PostContent.AppendHtml(content);
+        }
+    }
+
+    public record TaskSummaryItemViewModel
+    {
+        public TaskSummaryResponse TaskSummary { get; set; }
+
+        public string Href { get; set; }
+
+        public string Label { get; set; }
+    }
+}


### PR DESCRIPTION
Added a new tag helper for displaying task summary

The related links have been commented out for now, because we do not have all the required links specified

The framework is in place to wire this all up when required

We also have an open question on the back button behaviour when navigating from pupil numbers to a task and back again. This is a bit more challenging because it will have to navigate to different places based on where it came from