### PR TITLE
162855: increased field length of YR-Y11 (pre-16) capacity

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Configuration/Existing/PoConfiguration.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Configuration/Existing/PoConfiguration.cs
@@ -1197,7 +1197,7 @@ namespace Dfe.ManageFreeSchoolProjects.Data.Configuration.Existing
                 .IsUnicode(false)
                 .HasColumnName("Pupil numbers and capacity.YR PAN");
             builder.Property(e => e.PupilNumbersAndCapacityYrY11Pre16Capacity)
-                .HasMaxLength(4)
+                .HasMaxLength(100)
                 .IsUnicode(false)
                 .HasColumnName("Pupil numbers and capacity.YR-Y11 (pre-16) capacity");
             builder.Property(e => e.PupilNumbersAndCapacityYrY6Capacity)

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Migrations/20240416090252_IncreasePupilNumbersPre16CapacityFieldLength.Designer.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Migrations/20240416090252_IncreasePupilNumbersPre16CapacityFieldLength.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.ManageFreeSchoolProjects.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.ManageFreeSchoolProjects.Data.Migrations
 {
     [DbContext(typeof(MfspContext))]
-    partial class MfspContextModelSnapshot : ModelSnapshot
+    [Migration("20240416090252_IncreasePupilNumbersPre16CapacityFieldLength")]
+    partial class IncreasePupilNumbersPre16CapacityFieldLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Migrations/20240416090252_IncreasePupilNumbersPre16CapacityFieldLength.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.Data/Migrations/20240416090252_IncreasePupilNumbersPre16CapacityFieldLength.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.ManageFreeSchoolProjects.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class IncreasePupilNumbersPre16CapacityFieldLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Pupil numbers and capacity.YR-Y11 (pre-16) capacity",
+                schema: "dbo",
+                table: "PO",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(4)",
+                oldUnicode: false,
+                oldMaxLength: 4,
+                oldNullable: true)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "POHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "dbo")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart")
+                .OldAnnotation("SqlServer:IsTemporal", true)
+                .OldAnnotation("SqlServer:TemporalHistoryTableName", "POHistory")
+                .OldAnnotation("SqlServer:TemporalHistoryTableSchema", "dbo")
+                .OldAnnotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .OldAnnotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Pupil numbers and capacity.YR-Y11 (pre-16) capacity",
+                schema: "dbo",
+                table: "PO",
+                type: "varchar(4)",
+                unicode: false,
+                maxLength: 4,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldUnicode: false,
+                oldMaxLength: 100,
+                oldNullable: true)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "POHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "dbo")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart")
+                .OldAnnotation("SqlServer:IsTemporal", true)
+                .OldAnnotation("SqlServer:TemporalHistoryTableName", "POHistory")
+                .OldAnnotation("SqlServer:TemporalHistoryTableSchema", "dbo")
+                .OldAnnotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .OldAnnotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+        }
+    }
+}


### PR DESCRIPTION
this field is a total of two fields that have a maximum of 9999, therefore the original size 4, was never going to be enough

Since it is a total field, I have changed it to 100, to be consistent with the other totals fields on the table