### PR TITLE
Remove SAS dependency for Data Protection blob accessData protection

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.csproj
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.csproj
@@ -51,7 +51,7 @@
 
 	<ItemGroup>
 	  <PackageReference Include="AngleSharp" Version="1.0.5" />
-	  <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.2" />
+	  <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
 	  <PackageReference Include="DocumentFormat.OpenXml" Version="2.20.0" />
 	  <PackageReference Include="ExcelDataReader" Version="3.6.0" />
 	  <PackageReference Include="ExcelDataReader.DataSet" Version="3.6.0" />
@@ -66,9 +66,8 @@
 	  <PackageReference Include="Scrutor" Version="4.2.2" />
 	  <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
 	  <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
-	  <PackageReference Include="Azure.Core" Version="1.36.0" />
-	  <PackageReference Include="Azure.Identity" Version="1.10.4" />
-	  <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
+	  <PackageReference Include="Azure.Core" Version="1.38.0" />
+	  <PackageReference Include="Azure.Identity" Version="1.11.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/appsettings.json
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/appsettings.json
@@ -33,7 +33,7 @@
     "UseAcademisation": true,
     "UseAcademisationApplication": false
   },
-  "ConnectionStrings": {
-    "BlobStorage": ""
+  "DataProtection": {
+    "KeyVaultKey": ""
   }
 }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -136,8 +136,9 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v1.6.2 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v1.6.3 |
 | <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.4.1 |
+| <a name="module_data_protection"></a> [data\_protection](#module\_data\_protection) | github.com/DFE-Digital/terraform-azurerm-aspnet-data-protection | v1.0.0 |
 | <a name="module_statuscake-tls-monitor"></a> [statuscake-tls-monitor](#module\_statuscake-tls-monitor) | github.com/dfe-digital/terraform-statuscake-tls-monitor | v0.1.3 |
 
 ## Resources

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -172,6 +172,7 @@ No resources.
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN FrontDoor. This will use the Container Apps endpoint as the origin. | `bool` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor_health_probe"></a> [enable\_cdn\_frontdoor\_health\_probe](#input\_enable\_cdn\_frontdoor\_health\_probe) | Enable CDN Front Door health probe | `bool` | `false` | no |
 | <a name="input_enable_container_app_blob_storage"></a> [enable\_container\_app\_blob\_storage](#input\_enable\_container\_app\_blob\_storage) | Create an Azure Storage Account and Storage Container to be accessed by the Container App | `bool` | n/a | yes |
+| <a name="input_enable_container_app_file_share"></a> [enable\_container\_app\_file\_share](#input\_enable\_container\_app\_file\_share) | Create an Azure Storage Account and File Share to be mounted to the Container Apps | `bool` | n/a | yes |
 | <a name="input_enable_container_health_probe"></a> [enable\_container\_health\_probe](#input\_enable\_container\_health\_probe) | Enable liveness probes for the Container | `bool` | `true` | no |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
 | <a name="input_enable_dns_zone"></a> [enable\_dns\_zone](#input\_enable\_dns\_zone) | Conditionally create a DNS zone | `bool` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v1.6.2"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v1.6.3"
 
   environment    = local.environment
   project_name   = local.project_name

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -59,6 +59,7 @@ module "azure_container_apps_hosting" {
   cdn_frontdoor_health_probe_protocol = local.cdn_frontdoor_health_probe_protocol
 
   enable_container_app_blob_storage     = local.enable_container_app_blob_storage
+  enable_container_app_file_share       = local.enable_container_app_file_share
   storage_account_ipv4_allow_list       = local.storage_account_ipv4_allow_list
   storage_account_public_access_enabled = local.storage_account_public_access_enabled
 

--- a/terraform/data-protection.tf
+++ b/terraform/data-protection.tf
@@ -1,0 +1,11 @@
+module "data_protection" {
+  source = "github.com/DFE-Digital/terraform-azurerm-aspnet-data-protection?ref=v1.0.0"
+
+  data_protection_key_vault_assign_role   = false
+  data_protection_key_vault_subnet_prefix = "172.16.100.0/28"
+  data_protection_key_vault_access_ipv4   = local.key_vault_access_ipv4
+  data_protection_resource_prefix         = "${local.environment}${local.project_name}"
+  data_protection_azure_location          = local.azure_location
+  data_protection_tags                    = local.tags
+  data_protection_resource_group_name     = module.azure_container_apps_hosting.azurerm_resource_group_default.name
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -58,6 +58,7 @@ locals {
   statuscake_contact_group_integrations           = var.statuscake_contact_group_integrations
   statuscake_contact_group_email_addresses        = var.statuscake_contact_group_email_addresses
   enable_container_app_blob_storage               = var.enable_container_app_blob_storage
+  enable_container_app_file_share                 = var.enable_container_app_file_share
   storage_account_ipv4_allow_list                 = var.storage_account_ipv4_allow_list
   storage_account_public_access_enabled           = var.storage_account_public_access_enabled
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -407,6 +407,11 @@ variable "enable_container_app_blob_storage" {
   type        = bool
 }
 
+variable "enable_container_app_file_share" {
+  description = "Create an Azure Storage Account and File Share to be mounted to the Container Apps"
+  type        = bool
+}
+
 variable "storage_account_ipv4_allow_list" {
   description = "A list of public IPv4 address to grant access to the Blob Storage Account"
   type        = list(string)


### PR DESCRIPTION
Why do we need this?
The data protection keys were previously uploaded to Azure Storage as a Blob, using a Connection String that is expected to have a valid SAS Token appended to it. If that SAS token expires then the app will not have the ability to rotate/refresh the keys in Storage.

Without the ability to update the or access the key in the Blob Storage, the containers will get out of sync if there is more than 1 instance of the app running in a load balanced configuration.

What does this change do?

Deploys a 'File Share' that is shared between all containers. This is mounted at /srv/app/storage.
Change the Data Protection method to use the Local Filesystem (where the file share is mounted)
This means that all replicas of the app can share the same key
Deployed a Key Vault that contains a Cryptographic Key which will encrypt the master data protection key at rest.
If the Key Vault Key is supplied to the app, then the Data Protection keys will be encrypted at rest