### PR TITLE
Use a reusable GitHub Workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -15,7 +15,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
 
 env:
-  DOCKER_IMAGE: mfsp-app
   NODE_VERSION: 20.x
 
 jobs:
@@ -45,37 +44,31 @@ jobs:
           echo "release=${RELEASE}" >> $GITHUB_OUTPUT
           echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
 
-  build-and-push-image:
-    name: Build and push to ACR
-    needs: set-env
-    runs-on: ubuntu-22.04
-    environment: ${{ needs.set-env.outputs.environment }}
-    strategy:
-      matrix:
-        image: ['web', 'api']
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Azure Container Registry login
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.AZURE_ACR_CLIENTID }}
-          password: ${{ secrets.AZURE_ACR_SECRET }}
-          registry: ${{ secrets.AZURE_ACR_URL }}
-
-      - name: Build and push docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile.${{ matrix.image }}
-          tags: |
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ matrix.image }}-${{ needs.set-env.outputs.branch }}
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ matrix.image }}-${{ needs.set-env.outputs.release }}
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ matrix.image }}-sha-${{ needs.set-env.outputs.checked-out-sha }}
-            ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ matrix.image }}-latest
-          push: true
+  deploy-image:
+      name: Deploy '${{ needs.set-env.outputs.branch }}' to ${{ needs.set-env.outputs.environment }}
+      needs: [ set-env ]
+      uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v2.0.1
+      strategy:
+        matrix:
+          image: [
+            "web",
+            "api"
+          ]
+          include:
+            - image: "web"
+              aca_name_secret: "AZURE_ACA_NAME"
+            - image: "api"
+              aca_name_secret: "AZURE_API_ACA_NAME"
+      with:
+        docker-image-name: 'mfsp-${{ matrix.image }}'
+        docker-build-file-name: './Dockerfile.${{ matrix.image }}'
+        environment: ${{ needs.set-env.outputs.environment }}
+      secrets:
+        azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}
+        azure-acr-name: ${{ secrets.ACR_NAME }}
+        azure-aca-credentials: ${{ secrets.AZURE_ACA_CREDENTIALS }}
+        azure-aca-name: ${{ secrets[matrix.aca_name_secret] }}
+        azure-aca-resource-group: ${{ secrets.AZURE_ACA_RESOURCE_GROUP }}
 
   create-tag:
     name: Tag and release
@@ -110,46 +103,6 @@ jobs:
               core.setFailed(error.message);
             }
 
-  deploy-image:
-    name: Deploy to ${{ needs.set-env.outputs.environment }} (${{ needs.set-env.outputs.release }})
-    needs: [ build-and-push-image, set-env ]
-    runs-on: ubuntu-22.04
-    environment: ${{ needs.set-env.outputs.environment }}
-    strategy:
-      matrix:
-        image: ['web', 'api']
-    steps:
-      - name: Azure login with ACA credentials
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_ACA_CREDENTIALS }}
-
-      - name: Update Web Container Revision
-        uses: azure/CLI@v2
-        if: matrix.image == 'web'
-        with:
-          azcliversion: 2.45.0
-          inlineScript: |
-            az config set extension.use_dynamic_install=yes_without_prompt
-            az containerapp update \
-              --name ${{ secrets.AZURE_ACA_NAME }} \
-              --resource-group ${{ secrets.AZURE_ACA_RESOURCE_GROUP }} \
-              --image ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ matrix.image }}-${{ needs.set-env.outputs.release }} \
-              --output none
-
-      - name: Update API Container Revision
-        uses: azure/CLI@v2
-        if: matrix.image == 'api'
-        with:
-          azcliversion: 2.45.0
-          inlineScript: |
-            az config set extension.use_dynamic_install=yes_without_prompt
-            az containerapp update \
-              --name ${{ secrets.AZURE_API_ACA_NAME }} \
-              --resource-group ${{ secrets.AZURE_ACA_RESOURCE_GROUP }} \
-              --image ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ matrix.image }}-${{ needs.set-env.outputs.release }} \
-              --output none
-              
   cypress-tests:
     name: Run Cypress Tests
     if: needs.set-env.outputs.environment == 'staging' || needs.set-env.outputs.environment == 'development'


### PR DESCRIPTION
* switching to the reusable workflow ensures the release process is aligned to the other services within RSD
* this workflow is invoked using a matrix strategy which means it will build the api and app separately and they will be tagged as separate packages `"mfsp-app"` and `"mfsp-api"` whereas before they were both `"mfsp-app"` just with a different tag prefix of `"app-<release>"` or `"api-<release>"`. 
Having them as separate packages makes more sense because they are separate microservices