### PR TITLE
Docker build tag prefix

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -47,7 +47,7 @@ jobs:
   deploy-image:
       name: Deploy '${{ needs.set-env.outputs.branch }}' to ${{ needs.set-env.outputs.environment }}
       needs: [ set-env ]
-      uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v2.0.1
+      uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v2.1.0
       strategy:
         matrix:
           image: [
@@ -57,11 +57,14 @@ jobs:
           include:
             - image: "web"
               aca_name_secret: "AZURE_ACA_NAME"
+              tag_prefix: ""
             - image: "api"
               aca_name_secret: "AZURE_API_ACA_NAME"
+              tag_prefix: "api-"
       with:
-        docker-image-name: 'mfsp-${{ matrix.image }}'
+        docker-image-name: 'mfsp-app'
         docker-build-file-name: './Dockerfile.${{ matrix.image }}'
+        docker-tag-prefix: ${{ matrix.tag_prefix }}
         environment: ${{ needs.set-env.outputs.environment }}
       secrets:
         azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}


### PR DESCRIPTION
Waiting for https://github.com/DFE-Digital/deploy-azure-container-apps-action/pull/11

setting a tag prefix allows us to differentiate between the web app and the api docker images