### PR TITLE
Display Notification Banner above site if message is set

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Shared/_Layout.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Shared/_Layout.cshtml
@@ -71,6 +71,7 @@
 
 
 <partial name="_CookieBanner"/>
+<partial name="_NotificationBanner"/>
 <partial name="_BetaBanner" />
 <header class="dfe-header" role="banner">
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Shared/_NotificationBanner.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Shared/_NotificationBanner.cshtml
@@ -1,0 +1,24 @@
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
+
+@{
+  var notificationBannerMessage = Configuration["notificationBannerMessage"] ?? string.Empty;
+}
+
+@if (!string.IsNullOrWhiteSpace(notificationBannerMessage))
+{
+    <div class="dfe-width-container">
+        <section class="govuk-notification-banner govuk-!-margin-bottom-0" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Important
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p>
+                    @notificationBannerMessage
+                </p>
+            </div>
+        </section>
+    </div>
+}

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/appsettings.json
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/appsettings.json
@@ -35,5 +35,6 @@
   },
   "DataProtection": {
     "KeyVaultKey": ""
-  }
+  },
+  "notificationBannerMessage": ""
 }


### PR DESCRIPTION
Based on the work completed for Recast https://github.com/DFE-Digital/record-concerns-support-trusts/pull/1210

I have added a notification component that is wrapped by a conditional statement.

If the message value is set to a string (either via appsettings or env var) then it will display the component.

This is useful for displaying upcoming maintenance windows or important critical information (such as notification of IT outage)