### PR TITLE
Annotate App Insights for each deployment release

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -66,6 +66,7 @@ jobs:
         docker-build-file-name: './Dockerfile.${{ matrix.image }}'
         docker-tag-prefix: ${{ matrix.tag_prefix }}
         environment: ${{ needs.set-env.outputs.environment }}
+        annotate-release: ${{ needs.set-env.outputs.environment == 'development' && matrix.image == 'web' }}
       secrets:
         azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}
         azure-acr-name: ${{ secrets.ACR_NAME }}


### PR DESCRIPTION
This is currently limited to Dev for testing.

This change adds an extra step post-deployment to record a custom deployment event in App Insights with the SHA that corresponds with the release. This is useful so we can review performance metrics before and after a release

We only need this to run when the 'web' app is updated as both the api and the app share the same app insights instance.