### PR TITLE
Pin to 8.0.x for upstream security updates

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,5 @@
 ﻿# Stage 1
-ARG ASPNET_IMAGE_TAG=8.0.0-bookworm-slim
+ARG ASPNET_IMAGE_TAG=8.0-bookworm-slim
 ARG DOTNET_SDK_IMAGE_TAG=8.0
 
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_IMAGE_TAG} AS publish

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,5 @@
 ﻿# Stage 1
-ARG ASPNET_IMAGE_TAG=8.0.0-bookworm-slim
+ARG ASPNET_IMAGE_TAG=8.0-bookworm-slim
 ARG DOTNET_SDK_IMAGE_TAG=8.0
 ARG NODEJS_IMAGE_TAG=18-bullseye
 


### PR DESCRIPTION
Tracking the minor version ensures we can receive all upstream security patches from Microsoft such as for:
- CVE-2024-21392
- CVE-2024-21386

