### PR TITLE
Set 'secure' flag on Anti Forgery cookie

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Startup.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Startup.cs
@@ -153,6 +153,11 @@ public class Startup
         services.AddSingleton<IAuthorizationHandler, HeaderRequirementHandler>();
         services.AddSingleton<IAuthorizationHandler, ClaimsRequirementHandler>();
 
+        services.AddAntiforgery(options =>
+        {
+            options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        });
+
         System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
 
     }


### PR DESCRIPTION
**What is the change?**
Set 'secure' flag on .AspNetCore.Antiforgery cookie

**Why do we need the change?**
All cookies set by the application must have httpOnly and secure flags set to adhere to recommended remediations in the 2024 ITHC.

**What is the impact?**
Will only take affect when existing cookies expire or are cleared

**Azure DevOps Ticket**
#171441 [ITHC] 6.1.6. Cookie misconfiguration