### PR TITLE
Annotate releases in App Insights for all environments

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -66,7 +66,7 @@ jobs:
         docker-build-file-name: './Dockerfile.${{ matrix.image }}'
         docker-tag-prefix: ${{ matrix.tag_prefix }}
         environment: ${{ needs.set-env.outputs.environment }}
-        annotate-release: ${{ needs.set-env.outputs.environment == 'development' && matrix.image == 'web' }}
+        annotate-release: ${{ matrix.image == 'web' }}
       secrets:
         azure-acr-credentials: ${{ secrets.ACR_CREDENTIALS }}
         azure-acr-name: ${{ secrets.ACR_NAME }}


### PR DESCRIPTION
* The condition ensures that when the api container deploys there is not an additional marker in app insights. We dont want this to happen because they are both deployed at the same time and share the same app insights instance