### PR TITLE
Include project type in homepage tests

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/api/domain.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/api/domain.ts
@@ -29,6 +29,7 @@ export type CreateProjectRequest = {
 export type ProjectDetailsRequest = {
     projectId: string;
     schoolName: string;
+    projectType: string;
     applicationNumber: string;
     applicationWave: string;
     region?: string;

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/api/requestBuilder.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/api/requestBuilder.ts
@@ -11,6 +11,7 @@ export class RequestBuilder {
             applicationNumber: v4().substring(0, 9),
             createdBy: Cypress.env(EnvUsername),
             schoolName: dataGenerator.generateSchoolName(),
+            projectType: "Presumption",
             TRN: 'TR00111',
             applicationWave: "FS - Presumption",
             projectAssignedToName: "Test Person",

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/homepage.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/homepage.cy.ts
@@ -32,7 +32,7 @@ describe("Testing the home page", () => {
             });
         });
 
-        it("Should be able to filter projects by project ID", () => {
+        it.only("Should be able to filter projects by project ID", () => {
             homePage.openFilter().withProjectFilter(projectTitlePrefix).applyFilters();
 
             projectTable
@@ -40,6 +40,7 @@ describe("Testing the home page", () => {
                 .then((row) => {
                     row.hasProjectId(firstProject.projectId);
                     row.hasProjectTitle(firstProject.schoolName);
+                    row.hasProjectType(firstProject.projectType);
                     row.hasStatus("Pre-opening");
                 });
 
@@ -48,6 +49,7 @@ describe("Testing the home page", () => {
                 .then((row) => {
                     row.hasProjectId(secondProject.projectId);
                     row.hasProjectTitle(secondProject.schoolName);
+                    row.hasProjectType(firstProject.projectType);
                     row.hasStatus("Pre-opening");
                 });
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/projectRow.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/projectRow.ts
@@ -13,6 +13,12 @@ export class ProjectRow {
         return this;
     }
 
+    public hasProjectType(value: string): this {
+        this.containsText("project-type", value);
+
+        return this;
+    }
+    
     public hasTrustName(value: string): this {
         this.containsText("trust-name", value);
 


### PR DESCRIPTION
Include project type in homepage test to make sure it's displaying on the Project list page.
![project type_cypress](https://github.com/user-attachments/assets/c61b7abd-a122-458d-8cb0-8f451d6faf7e)
