### PR TITLE
Set HTTP user agent header

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Startup.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Startup.cs
@@ -153,6 +153,7 @@ public class Startup
             MfspOptions mfspOptions = GetTypedConfigurationFor<MfspOptions>();
             client.BaseAddress = new Uri(mfspOptions.ApiEndpoint);
             client.DefaultRequestHeaders.Add("ApiKey", mfspOptions.ApiKey);
+            client.DefaultRequestHeaders.Add("User-Agent", "ManageFreeSchoolProjects/1.0");
         });
 
         services.AddScoped<ErrorService>();


### PR DESCRIPTION
Set a custom User-Agent HTTP Header so that traffic can be segmented when running reports against the downstream APIs