### PR TITLE
Readiness to Open meeting test fix

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/taskListPage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/taskListPage.ts
@@ -159,6 +159,11 @@ class TaskListPage {
         return this;
     }
 
+    public selectReadinessToOpenMeetingFromTaskList(): this {
+        cy.getByTestId("readinessToOpenMeeting-task").click()
+        return this;
+    }
+
     public selectMovingToOpenFromTaskList(): this {
         cy.getByTestId("movingToOpen-task").click()
         return this;


### PR DESCRIPTION
Missed to push this change . It should fix the ROM test
<img width="543" alt="ROM_ cypress test" src="https://github.com/user-attachments/assets/4ca4cf55-fd8a-47e4-a9d1-9ec55c00c143">
