### PR TITLE
Create bulk edit

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/update-multiple-fields.cy.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/e2e/update-multiple-fields.cy.ts
@@ -1,0 +1,53 @@
+import { Logger } from "cypress/common/logger";
+import { ProjectRecordCreator } from "cypress/constants/cypressConstants";
+import homePage from "cypress/pages/homePage";
+import updateMultipleFields from "cypress/pages/updateMultipleFields";
+import checkYourAnswers from "cypress/pages/checkYourAnswers";
+
+describe("Update multiple fields - Bulk edit", () => {
+    beforeEach(() => {
+        cy.login({ role: "POTATO" });
+        cy.visit(Cypress.env('url'));
+    });
+
+    describe("Update multiple fields of projects", () => {
+        beforeEach(() => {
+            cy.login({ role: ProjectRecordCreator });
+            cy.visit('/');
+        });
+
+        it("should able to upload a csv or  xlsx file", () => {
+            Logger.log(" Navigate to update multiple fields card");
+            cy.contains('Update multiple fields').should('be.visible');
+            cy.executeAccessibilityTests();
+            homePage.updateMultipleFields();
+            cy.executeAccessibilityTests();
+            //upload without selecting any file
+            updateMultipleFields
+                .clickUpload()
+                .errorForUpload('Select a file')
+            cy.executeAccessibilityTests();
+
+            //upload a valid xlsx file
+            cy.fixture('bulk-edit-records.xlsx').then(fileContent => {
+                cy.get('[data-testid="upload"]').attachFile({
+                    fileContent: fileContent,
+                    fileName: 'bulk-edit-records.xlsx',
+                    mimeType: 'text/zip'
+
+                })
+            })
+
+            updateMultipleFields
+                .clickUpload()
+            checkYourAnswers
+                .recordsVisible()
+                .editProjects()
+
+            cy.get('.govuk-panel').should('contain.text', 'free school projects edited')
+
+
+        });
+    });
+
+});    

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/fixtures/bulk-edit-records.xlsx
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/fixtures/bulk-edit-records.xlsx
@@ -1,0 +1,2 @@
+Project_ID,Project_status,Actual_opening_date,Local_Authority
+T00214555,Closed,07/10/2029,381

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/checkYourAnswers.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/checkYourAnswers.ts
@@ -1,0 +1,27 @@
+class CheckYourAnswers {
+
+    public chooseFile(): this {
+        cy.get('input[name="upload"]').click();
+        return this;
+    }
+
+    public editProjects(): this {
+        cy.contains('button','Edit projects').click()
+        return this;
+    }
+
+    public checkYourAnswersHeading(string): this {
+        cy.get('.govuk-heading-xl').should('contain.text', string)
+        return this;
+    }
+
+    public recordsVisible(): this {
+        cy.get('.govuk-heading-xl').contains('Check your answers')
+        cy.get('.govuk-summary-card__content').should('have.length', 1)
+        return this;
+    }
+}
+
+const checkYourAnswers = new CheckYourAnswers();
+
+export default checkYourAnswers;

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/homePage.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/homePage.ts
@@ -12,6 +12,11 @@ class HomePage {
         return this;
     }
 
+    public updateMultipleFields(): this {
+        cy.get('.dfe-card').contains('Update multiple fields').click();
+
+        return this;
+    }
     public deleteProject(): this {
         cy.getByTestId("delete-project-button").click();
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/updateMultipleFields.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/pages/updateMultipleFields.ts
@@ -1,0 +1,17 @@
+class UpdateMultipleFields {
+
+    public clickUpload(): this {
+        cy.contains('button','Upload').click()
+        return this;
+    }
+    
+    public errorForUpload(error: string): this {
+        cy.get('.govuk-error-summary').should('contains.text', error)
+        return this
+    }
+  
+}
+
+const updateMultipleFields = new UpdateMultipleFields();
+
+export default updateMultipleFields;

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/support/commands.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/support/commands.ts
@@ -3,6 +3,7 @@ import "cypress-axe";
 import { AuthenticationInterceptor } from "../auth/authenticationInterceptor";
 import { Logger } from "../common/logger";
 import { RuleObject } from "axe-core";
+import "cypress-file-upload";
 
 Cypress.Commands.add("getByTestId", (id) => {
     cy.get(`[data-testid="${id}"]`);

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/support/e2e.ts
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/support/e2e.ts
@@ -16,6 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import { AuthenticationInterceptorParams } from "cypress/auth/authenticationInterceptor";
 import "./commands";
+import 'cypress-file-upload';
 import { RuleObject } from "axe-core";
 import {EnvAuthKey} from "../constants/cypressConstants";
 const registerCypressGrep = require('@cypress/grep')


### PR DESCRIPTION
This PR covers the Create bulk edit test however not running successfully atm. 
Note : I have used Cypress-file-upload plugin, which adds support for file upload testing to Cypress, by running the following command in terminal:
npm install --save-dev cypress-file-upload

Test passed once however now I am getting `File cannot be read` error. 

We could also cover other scenarios like : all validation checks - empty file, incorrect data, uploading invalid file type etc once the current issue is resolved