### PR TITLE
Add DbContextChecks to Health Checks

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Dfe.ManageFreeSchoolProjects.API.csproj
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Dfe.ManageFreeSchoolProjects.API.csproj
@@ -39,6 +39,7 @@
       </PackageReference>
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.11" />
       <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.3" />
       <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.22.0" />
       <PackageReference Include="OfficeOpenXml.Core.ExcelPackage" Version="1.0.0" />

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Startup.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Startup.cs
@@ -81,6 +81,8 @@ namespace Dfe.ManageFreeSchoolProjects.API
             app.UseAuthorization();
 
             app.UseManageFreeSchoolProjectsEndpoints();
+
+            app.UseHealthChecks("/health");
         }
     }
 }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/StartupConfiguration/DatabaseConfigurationExtensions.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/StartupConfiguration/DatabaseConfigurationExtensions.cs
@@ -13,6 +13,13 @@ public static class DatabaseConfigurationExtensions
 
 		services.AddScoped<AuditInterceptor, AuditInterceptor>();
 
+		AddDbHealthCheck(services);
+
 		return services;
+	}
+
+	public static void AddDbHealthCheck(IServiceCollection services) {
+		services.AddHealthChecks()
+			.AddDbContextCheck<MfspContext>("Manage Free School Projects Database");
 	}
 }

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Startup.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Startup.cs
@@ -64,7 +64,6 @@ public class Startup
     {
         services.AddHttpClient();
         services.AddFeatureManagement();
-        services.AddHealthChecks();
         services
            .AddRazorPages(options =>
            {
@@ -72,7 +71,7 @@ public class Startup
                options.Conventions.AllowAnonymousToPage("/Public/AccessibilityStatement");
                options.Conventions.AllowAnonymousToPage("/Public/Cookies");
                options.Conventions.AllowAnonymousToPage("/Account/AccessDenied");
-           }) 
+           })
            .AddViewOptions(options =>
            {
                options.HtmlHelperOptions.ClientValidationEnabled = false;
@@ -118,7 +117,7 @@ public class Startup
         services.AddScoped<IUpdateProjectPaymentsService, UpdateProjectPaymentsService>();
         services.AddScoped<IAddProjectPaymentsService, AddProjectPaymentsService>();
         services.AddScoped<IDeleteProjectPaymentsService, DeleteProjectPaymentsService>();
-        services.AddScoped<IGrantLettersService, GrantLettersService>(); 
+        services.AddScoped<IGrantLettersService, GrantLettersService>();
         services.AddScoped<IPDGPaymentInfoService, PDGPaymentInfoService>();
         services.AddScoped<IBulkEditFileReader, BulkEditFileReader>();
         services.AddScoped<IBulkEditFileValidator, BulkEditFileValidator>();
@@ -181,6 +180,8 @@ public class Startup
         });
 
         System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+
+        SetupHealthChecks(services);
     }
 
     private void SetupDataprotection(IServiceCollection services)
@@ -200,6 +201,11 @@ public class Startup
           credentials
         );
       }
+    }
+
+    private static void SetupHealthChecks(IServiceCollection services)
+    {
+      services.AddHealthChecks();
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)


### PR DESCRIPTION
This will ensure that the healthcheck endpoint correctly reports the status of the service if a database connection faults