### PR TITLE
Use Cypress.io GitHub Action

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -29,15 +29,18 @@ on:
 concurrency:
   group: ${{ github.workflow }}
 
-env:
-  NODE_VERSION: 18.x
-
 jobs:
   cypress-tests:
     name: Run Cypress Tests
-    if: inputs.environment == 'test' || inputs.environment == 'development'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    strategy:
+      matrix:
+        browser: [
+          "edge"
+        ]
+    container:
+      image: cypress/browsers:22.12.0
     defaults:
       run:
         working-directory: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests
@@ -46,27 +49,50 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Setup node.js
-        uses: actions/setup-node@v4
+      - name: Prepare Cypress cache
+        uses: cypress-io/github-action@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          runTests: false
+          browser: ${{ matrix.browser }}
+          working-directory: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests
 
-      - name: Npm install
-        run: npm install
-
-      - name: Run cypress (dev)
+      - name: Run (dev)
         if: inputs.environment == 'development'
-        run: npm run cy:run -- --env grepTags='-smoke',username=${{ secrets.USERNAME }},url=${{ secrets.AZURE_WEB_ENDPOINT }},api=${{ secrets.AZURE_API_ENDPOINT }},apiKey=${{ secrets.AZURE_API_KEY }},authKey=${{secrets.CYPRESS_TEST_SECRET}}
+        uses: cypress-io/github-action@v6
+        env:
+          CYPRESS_username: ${{ secrets.USERNAME }}
+          CYPRESS_grepTags: '-smoke'
+          CYPRESS_url: ${{ secrets.AZURE_WEB_ENDPOINT }}
+          CYPRESS_apiKey: ${{ secrets.AZURE_API_KEY }}
+          CYPRESS_authKey: ${{ secrets.CYPRESS_TEST_SECRET }}
+          CYPRESS_api: ${{ secrets.AZURE_API_ENDPOINT }}
+        with:
+          browser: ${{ matrix.browser }}
+          working-directory: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests
+          wait-on: ${{ secrets.AZURE_ENDPOINT }}
+          install: false
 
-      - name: Run cypress (test)
+      - name: Run (test)
         if: inputs.environment == 'test'
-        run: npm run cy:smoke -- --env username=${{ secrets.USERNAME }},url=${{ secrets.AZURE_WEB_ENDPOINT }},api=${{ secrets.AZURE_API_ENDPOINT }},apiKey=${{ secrets.AZURE_API_KEY }},authKey=${{secrets.CYPRESS_TEST_SECRET}}
+        uses: cypress-io/github-action@v6
+        env:
+          CYPRESS_username: ${{ secrets.USERNAME }}
+          CYPRESS_url: ${{ secrets.AZURE_WEB_ENDPOINT }}
+          CYPRESS_apiKey: ${{ secrets.AZURE_API_KEY }}
+          CYPRESS_authKey: ${{ secrets.CYPRESS_TEST_SECRET }}
+          CYPRESS_api: ${{ secrets.AZURE_API_ENDPOINT }}
+        with:
+          browser: ${{ matrix.browser }}
+          working-directory: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests
+          wait-on: ${{ secrets.AZURE_ENDPOINT }}
+          spec: cypress/e2e/smoke/*
+          install: false
 
       - name: Upload screenshots
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots-${{ inputs.environment }}
+          name: screenshots-${{ inputs.environment }}-${{ matrix.browser }}
           path: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/cypress/screenshots
 
       - name: Generate report
@@ -79,7 +105,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: reports-${{ inputs.environment }}
+          name: reports-${{ inputs.environment }}-${{ matrix.browser }}
           path: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests/mochareports
 
       - name: Report results


### PR DESCRIPTION
- These changes update the Cypress GitHub Workflow so that it will use the official Cypress GitHub Action for executing Cypress Tests. This will enable us to make use of caching, and standardises the approach across all of the other RSD services.
- I have also enabled the workflow_dispatch trigger so that Cypress tests can be run manually against a target environment
- Using a 'matrix' strategy will also enable us to test against multiple browsers in the future if we decide to do so