### PR TITLE
Make casing consistent to match Cypress test expectation

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Create/Individual/CheckYourAnswers.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Create/Individual/CheckYourAnswers.cshtml
@@ -13,7 +13,7 @@
 
     var faithType = Model.Project.FaithType == FaithType.Other ? $"Other - {Model.Project.OtherFaithType}" : Model.Project.FaithType.ToDescription();
     var faithTypeLink = Model.Project.FaithStatus == FaithStatus.None ? RouteConstants.CreateFaithStatus : RouteConstants.CreateFaithType;
-    
+
     var ageRangeValue = string.Empty;
     var projectAgeRange = Model.Project.AgeRange;
     if (projectAgeRange.Contains('-'))
@@ -47,7 +47,7 @@
                 @RenderSummaryRow("Application wave", Model.Project.ApplicationWave, RouteConstants.CreateApplicationWave)
             }
 
-            @RenderSummaryRow("Temporary project ID", Model.Project.ProjectId, RouteConstants.CreateProjectId)
+            @RenderSummaryRow("Temporary Project ID", Model.Project.ProjectId, RouteConstants.CreateProjectId)
             @RenderSummaryRow("Current free school name", Model.Project.SchoolName, RouteConstants.CreateProjectSchool)
 
 

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Create/Individual/Confirmation.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Create/Individual/Confirmation.cshtml
@@ -1,7 +1,7 @@
 ﻿@page "/project/create/confirmation"
 @model Dfe.ManageFreeSchoolProjects.Pages.Project.Create.Individual.ConfirmationModel
 @{
-    ViewData["Title"] = "Confirmation"; 
+    ViewData["Title"] = "Confirmation";
 }
 
 <div class="govuk-grid-row">
@@ -11,7 +11,7 @@
                 Free school project created
             </h1>
             <div class="govuk-panel__body">
-                Temporary project ID<br><strong data-testid="created-project-id" >@Model.ProjectID</strong>
+                Temporary Project ID<br><strong data-testid="created-project-id" >@Model.ProjectID</strong>
             </div>
         </div>
         <p data-testid="confirmation-email">

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Create/Individual/ProjectId.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Project/Create/Individual/ProjectId.cshtml
@@ -1,7 +1,7 @@
 ﻿@page "/project/create/projectid"
 @model Dfe.ManageFreeSchoolProjects.Pages.Project.Create.Individual.ProjectIdModel
 @{
-    ViewData["Title"] = "What is the temporary project ID?";
+    ViewData["Title"] = "What is the Temporary Project ID?";
 }
 @section BeforeMain {
     <div role="navigation" class="govuk-width-container">
@@ -14,7 +14,7 @@
         <form class="form" method="post">
 
             <div class="govuk-form-group">
-                <govuk-create-title label="What is the temporary project ID?" for="projectid" />
+                <govuk-create-title label="What is the Temporary Project ID?" for="projectid" />
                 <govuk-text-input id="projectid" name="projectid" asp-for="@Model.ProjectId" data-testid="projectid" hint="For example, W3456" />
             </div>
 


### PR DESCRIPTION
- Cypress smoke tests are failing in 'Test' env because there is a difference in the written text casing for `Temporary project ID`