### PR TITLE
Split workflow into concurrent build and import stages

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -20,70 +20,110 @@ env:
 jobs:
   set-env:
     name: Determine environment
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.var.outputs.environment }}
-      branch: ${{ steps.var.outputs.branch }}
       release: ${{ steps.var.outputs.release }}
-      checked-out-sha: ${{ steps.var.outputs.checked-out-sha }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - id: var
         run: |
-          GIT_REF=${{ github.ref }}
-          GIT_BRANCH=${GIT_REF##*/}
           INPUT=${{ github.event.inputs.environment }}
           ENVIRONMENT=${INPUT:-"development"}
           RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
-          CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
-          echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
           echo "release=${RELEASE}" >> $GITHUB_OUTPUT
-          echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
 
-  deploy-image:
-      permissions:
-        id-token: write
-        contents: read
-        packages: write
-      name: Deploy '${{ needs.set-env.outputs.branch }}' to ${{ needs.set-env.outputs.environment }}
-      needs: [ set-env ]
-      uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v3.1.0
-      strategy:
-        matrix:
-          image: [
-            "web",
-            "api"
-          ]
-          include:
-            - image: "web"
-              aca_name_secret: "ACA_CONTAINERAPP_NAME"
-              tag_prefix: ""
-            - image: "api"
-              aca_name_secret: "ACA_CONTAINERAPP_API_NAME"
-              tag_prefix: "api-"
-      with:
-        docker-image-name: 'mfsp-app'
-        docker-build-file-name: './Dockerfile.${{ matrix.image }}'
-        docker-tag-prefix: ${{ matrix.tag_prefix }}
-        environment: ${{ needs.set-env.outputs.environment }}
-        annotate-release: ${{ matrix.image == 'web' }}
-      secrets:
-        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-        azure-acr-client-id: ${{ secrets.ACR_CLIENT_ID }}
-        azure-acr-name: ${{ secrets.ACR_NAME }}
-        azure-aca-client-id: ${{ secrets.ACA_CLIENT_ID }}
-        azure-aca-name: ${{ secrets[matrix.aca_name_secret] }}
-        azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
+  build:
+    name: Build
+    needs: [ set-env ]
+    permissions:
+      packages: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build.yml@v4.1.0
+    strategy:
+      matrix:
+        image: [
+          "web",
+          "api"
+        ]
+        include:
+          - image: "web"
+            tag-prefix: ""
+          - image: "api"
+            tag-prefix: "api-"
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: 'mfsp-app'
+      docker-build-file-name: ./Dockerfile.${{ matrix.image }}
+      docker-build-context: ${{ inputs.docker-build-context }}
+      docker-build-args: ${{ inputs.docker-build-args }}
+      docker-tag-prefix: ${{ matrix.tag-prefix }}
+
+  import:
+    name: Import
+    needs: [ set-env, build ]
+    permissions:
+      id-token: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/import.yml@v4.1.0
+    strategy:
+      matrix:
+        image: [
+          "web",
+          "api"
+        ]
+        include:
+          - image: "web"
+            tag-prefix: ""
+          - image: "api"
+            tag-prefix: "api-"
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: 'mfsp-app'
+      docker-tag-prefix: ${{ matrix.tag-prefix }}
+    secrets:
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure-acr-client-id: ${{ secrets.ACR_CLIENT_ID }}
+      azure-acr-name: ${{ secrets.ACR_NAME }}
+
+  deploy:
+    name: Deploy
+    needs: [ set-env, import ]
+    permissions:
+      id-token: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/deploy.yml@v4.1.0
+    strategy:
+      matrix:
+        image: [
+          "web",
+          "api"
+        ]
+        include:
+          - image: "web"
+            tag-prefix: ""
+            aca_name_secret: "ACA_CONTAINERAPP_NAME"
+          - image: "api"
+            tag-prefix: "api-"
+            aca_name_secret: "ACA_CONTAINERAPP_API_NAME"
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: 'mfsp-app'
+      docker-tag-prefix: ${{ matrix.tag-prefix }}
+      annotate-release: ${{ matrix.image == 'web' }}
+    secrets:
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure-acr-name: ${{ secrets.ACR_NAME }}
+      azure-aca-client-id: ${{ secrets.ACA_CLIENT_ID }}
+      azure-aca-name: ${{ secrets[matrix.aca_name_secret] }}
+      azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
 
   create-tag:
     name: Tag and release
-    needs: set-env
-    runs-on: ubuntu-22.04
+    needs: [ set-env, deploy ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -116,7 +156,7 @@ jobs:
   cypress-tests:
     name: Run Cypress Tests
     if: needs.set-env.outputs.environment == 'test' || needs.set-env.outputs.environment == 'development'
-    needs: [ deploy-image, set-env ]
+    needs: [ deploy, set-env ]
     uses: ./.github/workflows/cypress-tests.yml
     with:
       environment: ${{ needs.set-env.outputs.environment }}


### PR DESCRIPTION
- This change ensures that both the web and api images get built, imported and restarted at the same time.
- Build and import tasks run in parallel
- The workflow is easier to manipulate at different stages