### PR TITLE
Run MFSP cypress tests parallelly

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -39,6 +39,7 @@ jobs:
         browser: [
           "edge"
         ]
+        parallel: [ 'worker1', 'worker2', 'worker3' ] 
     container:
       image: cypress/browsers:22.13.1
     defaults:
@@ -55,6 +56,7 @@ jobs:
           runTests: false
           browser: ${{ matrix.browser }}
           working-directory: Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.CypressTests
+          run: cypress run --parallel
 
       - name: Run (dev)
         if: inputs.environment == 'development'


### PR DESCRIPTION
MFSP project has a large number of cypress tests in it's cypress test suite which takes more than 20 minutes to finish. Would like to see if running Cypress tests in parallel through your CI pipeline, improves the speed and efficiency of the test runs. 