### PR TITLE
Wait for quality gate response from Sonar before finishing the workflow

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -69,8 +69,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          dotnet-sonarscanner begin /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital_manage-free-schools-projects" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=./Dfe.ManageFreeSchoolProjects/CoverageReport/SonarQube.xml
+          dotnet-sonarscanner begin /d:sonar.qualitygate.wait=true /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital_manage-free-schools-projects" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=./Dfe.ManageFreeSchoolProjects/CoverageReport/SonarQube.xml
           dotnet build Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.sln --no-restore
-          dotnet test Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.sln --no-build --verbosity normal --collect:"XPlat Code Coverage" --environment "${{env.CONNECTION_STRING_KEY}}"="${{env.CONNECTION_STRING}}"
+          dotnet test Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.sln --no-build --verbosity normal --collect:"XPlat Code Coverage" --environment "${{ env.CONNECTION_STRING_KEY }}"="${{ env.CONNECTION_STRING }}"
           reportgenerator -reports:"./**/coverage.cobertura.xml" -targetdir:./Dfe.ManageFreeSchoolProjects/CoverageReport -reporttypes:SonarQube
           dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
This forms part of the work to make Sonarqube a mandatory quality gate.
Introducing the `sonar.qualitygate.wait=true` parameter ensures that the scanner will wait for the report to be generated and will fail the workflow if the gate is red, rather than completing the workflow regardless of the gate