### PR TITLE
Include NotificationBanner on NoHeaderAndFooter Layout

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Shared/_LayoutNoHeaderAndFooter.cshtml
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects/Pages/Shared/_LayoutNoHeaderAndFooter.cshtml
@@ -55,6 +55,7 @@
 
 <div class="govuk-width-container">
 	@await RenderSectionAsync("BeforeMain", required: false)
+	<partial name="_NotificationBanner" />
 	<main class="govuk-main-wrapper gov-main-wrapper--auto-spacing" id="main-content" role="main">
 		@RenderBody()
 	</main>


### PR DESCRIPTION
Ensure the maintenance banner appears on pages that do not use the default header layout