### PR TITLE
Changed "Withdrawn in pre-opening" to "Withdrawn during pre-opening"

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Project/ProjectMapperTests.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API.Tests/Project/ProjectMapperTests.cs
@@ -74,7 +74,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.Tests.Project
         //[InlineData("AnyNotRecognised", ProjectStatus.Preopening)]
         [InlineData(ProjectStatus.Cancelled, "Cancelled during pre-opening")]
         [InlineData(ProjectStatus.Closed, "Closed")]
-        [InlineData(ProjectStatus.WithdrawnInPreOpening, "Withdrawn in pre-opening")]
+        [InlineData(ProjectStatus.WithdrawnInPreOpening, "Withdrawn during pre-opening")]
         [InlineData(ProjectStatus.ApplicationCompetitionStage, "Application Competition stage")]
         [InlineData(ProjectStatus.ApplicationStage, "Application stage")]
         [InlineData(ProjectStatus.OpenNotIncludedInFigures, "Open free school - Not included in figures")]

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/ProjectMapper.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/ProjectMapper.cs
@@ -114,7 +114,7 @@ namespace Dfe.ManageFreeSchoolProjects.API.UseCases.Project
                 ProjectStatusType.Open => "Open",
                 ProjectStatusType.Closed => "Closed",
                 ProjectStatusType.Cancelled => "Cancelled during pre-opening",
-                ProjectStatusType.WithdrawnInPreOpening => "Withdrawn in pre-opening",
+                ProjectStatusType.WithdrawnInPreOpening => "Withdrawn during pre-opening",
                 ProjectStatusType.Rejected => "Rejected at application stage",
                 ProjectStatusType.ApplicationCompetitionStage => "Application Competition stage",
                 ProjectStatusType.ApplicationStage => "Application stage",


### PR DESCRIPTION
For ticket: https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/230789

We have had a request to change "Withdrawn in pre-opening" to "Withdrawn during pre-opening". This has already been fixed in the data and it was already defensively implemented to accept both but was saving as "in". 